### PR TITLE
Expose libro UI helpers globally

### DIFF
--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -173,3 +173,10 @@ async function cargarSolicitudesRecibidas(userId) {
         return [];
     }
 }
+
+// Exponer helpers a nivel global
+window.cargarYMostrarLibros = cargarYMostrarLibros;
+window.asignarEventListenersLibros = asignarEventListenersLibros;
+window.cargarMisLibrosEnPrestamo = cargarMisLibrosEnPrestamo;
+window.cargarLibrosQueMePrestaron = cargarLibrosQueMePrestaron;
+window.cargarSolicitudesRecibidas = cargarSolicitudesRecibidas;


### PR DESCRIPTION
## Summary
- attach libro helper functions to the global `window` object in `libros_ui.js`

## Testing
- `node --check js/libros_ui.js`
- `node - <<'NODE'
  global.window = {};
  require('./js/libros_ui.js');
  console.log('exposed functions:', Object.keys(window));
  NODE`

------
https://chatgpt.com/codex/tasks/task_e_6842fff1f9548329bbfbd851ff4a367b