### PR TITLE
Implement auto refresh for notifications

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -8,7 +8,8 @@ async function cerrarSesion() {
         const { error } = await supabaseClientInstance.auth.signOut();
         if (error) { console.error('DEBUG: auth.js - Error al cerrar sesión de admin:', error); /* No alert */ }
     }
-    currentUser = null; localStorage.removeItem('libroVaUser'); 
+    detenerMonitoreoNotificaciones();
+    currentUser = null; localStorage.removeItem('libroVaUser');
     console.log('DEBUG: auth.js - Sesión cerrada localmente.');
     renderizarVistaBienvenida(); // Asume que renderizarVistaBienvenida es global
     actualizarMenuPrincipal(); // Asume que actualizarMenuPrincipal es global
@@ -23,6 +24,7 @@ async function loginAdmin(email, password) {
     if (data.user) {
         console.log('DEBUG: auth.js - Admin logueado:', data.user);
         currentUser = { id: data.user.id, email: data.user.email, rol: 'admin', reputacion: 'N/A' }; // Actualiza currentUser global
+        iniciarMonitoreoNotificaciones();
         return currentUser;
     }
     return null;
@@ -43,7 +45,9 @@ async function registrarAlumno(nickname, idAvatarSeleccionado, pin) {
     const { data, error } = await supabaseClientInstance.from('usuarios').insert([{ nickname: nicknameLimpio, nombre_avatar: nombreAvatarParaGuardar, pin: pin, rol: 'alumno', reputacion: 0 }]).select().single();
     if (error) { console.error('DEBUG: auth.js - Error al registrar alumno:', error); alert(`Error al registrar: ${error.message}`); return null; }
     console.log('DEBUG: auth.js - Alumno registrado:', data);
-    currentUser = data; localStorage.setItem('libroVaUser', JSON.stringify(currentUser)); return currentUser; // Actualiza currentUser global
+    currentUser = data; localStorage.setItem('libroVaUser', JSON.stringify(currentUser));
+    iniciarMonitoreoNotificaciones();
+    return currentUser; // Actualiza currentUser global
 }
 
 async function loginAlumno(nombreAvatarSeleccionado, pin) {
@@ -57,5 +61,7 @@ async function loginAlumno(nombreAvatarSeleccionado, pin) {
         return null;
     }
     console.log('DEBUG: auth.js - Alumno logueado:', data);
-    currentUser = data; localStorage.setItem('libroVaUser', JSON.stringify(currentUser)); return currentUser; // Actualiza currentUser global
+    currentUser = data; localStorage.setItem('libroVaUser', JSON.stringify(currentUser));
+    iniciarMonitoreoNotificaciones();
+    return currentUser; // Actualiza currentUser global
 }

--- a/js/globals.js
+++ b/js/globals.js
@@ -9,3 +9,4 @@ let menuPrincipal = null;
 
 let notificaciones = [];
 let notificacionesNuevas = 0;
+let notificacionesIntervalId = null;

--- a/js/notificaciones.js
+++ b/js/notificaciones.js
@@ -50,6 +50,24 @@ async function refrescarNotificaciones() {
     if (!currentUser) return;
     notificaciones = await cargarNotificacionesUsuario(currentUser.id);
     notificacionesNuevas = notificaciones.filter(n => !n.leida).length;
+    actualizarMenuPrincipal();
 }
 
 window.refrescarNotificaciones = refrescarNotificaciones;
+
+function iniciarMonitoreoNotificaciones() {
+    detenerMonitoreoNotificaciones();
+    if (!currentUser) return;
+    refrescarNotificaciones();
+    notificacionesIntervalId = setInterval(refrescarNotificaciones, 60000);
+}
+
+function detenerMonitoreoNotificaciones() {
+    if (notificacionesIntervalId) {
+        clearInterval(notificacionesIntervalId);
+        notificacionesIntervalId = null;
+    }
+}
+
+window.iniciarMonitoreoNotificaciones = iniciarMonitoreoNotificaciones;
+window.detenerMonitoreoNotificaciones = detenerMonitoreoNotificaciones;


### PR DESCRIPTION
## Summary
- add polling control global state
- refresh notifications periodically
- start polling on login and stop on logout
- update menu bell count after each fetch

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684769b7f8fc83298a70aff4d7d43b91