### PR TITLE
Fix test script reference

### DIFF
--- a/test_index.html
+++ b/test_index.html
@@ -12,5 +12,5 @@
     <h1>Prueba de Conexión LibroVa con Supabase</h1>
     <div id="status">Inicializando prueba...</div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script> <script src="app_test.js"></script>   </body>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script> <script src="test_app_test.js"></script>   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix test script reference to `test_app_test.js` in test index

## Testing
- `curl file://$PWD/test_index.html | grep -o "test_app_test.js" -n`

------
https://chatgpt.com/codex/tasks/task_e_684802a17cf88329a97b3564cdd45154