### PR TITLE
Remove hardcoded Supabase keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _site/
 # counterproductive to check this file into the repository.
 # Details at https://github.com/github/pages-gem/issues/768
 Gemfile.lock
+js/config.js

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Luego visita `http://localhost:8000/index.html`.
 
 ## Credenciales de Supabase
 
-Los valores `SUPABASE_URL` y `SUPABASE_ANON_KEY` se encuentran definidos en el fichero [`js/config.js`](js/config.js). Estas mismas constantes también se utilizan en `app.js` y en `test_app_test.js` para inicializar el cliente de Supabase. Asegúrate de actualizar estos valores si cambias de proyecto en Supabase.
+Los valores `X_SUPABASE_URL` y `X_SUPABASE_ANON_KEY` se cargan desde variables de entorno o desde un archivo `js/config.js` que no está versionado. Copia [`js/config.sample.js`](js/config.sample.js) a `js/config.js` y completa tus credenciales, o bien define las variables de entorno `X_SUPABASE_URL` y `X_SUPABASE_ANON_KEY` antes de servir la página.
 
 ## Archivos de prueba
 

--- a/js/config.js
+++ b/js/config.js
@@ -1,8 +1,14 @@
 // js/config.js
 console.log("DEBUG: config.js - Cargado.");
 
-const SUPABASE_URL = 'https://srqdgsgxkxfiveynxkwt.supabase.co'; 
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNycWRnc2d4a3hmaXZleW54a3d0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg1Mjg2MjUsImV4cCI6MjA2NDEwNDYyNX0.xenXPUm17l0LvbvUk0fsbVik3y5uKP3ADwaVN5BcKGY';
+const X_SUPABASE_URL =
+    (typeof window !== 'undefined' && window.X_SUPABASE_URL) ||
+    (typeof process !== 'undefined' && process.env.X_SUPABASE_URL) ||
+    '';
+const X_SUPABASE_ANON_KEY =
+    (typeof window !== 'undefined' && window.X_SUPABASE_ANON_KEY) ||
+    (typeof process !== 'undefined' && process.env.X_SUPABASE_ANON_KEY) ||
+    '';
 
 const AVATARES_DISPONIBLES = [ 
     { id: 'avatar_robot', nombre: 'Robot', emoji: '🤖' }, { id: 'avatar_pelota', nombre: 'Pelota', emoji: '⚽️' },

--- a/js/config.sample.js
+++ b/js/config.sample.js
@@ -1,0 +1,4 @@
+// js/config.sample.js
+// Copia este archivo a config.js y completa tus credenciales
+window.X_SUPABASE_URL = '<TU_SUPABASE_URL>';
+window.X_SUPABASE_ANON_KEY = '<TU_SUPABASE_ANON_KEY>';

--- a/js/main.js
+++ b/js/main.js
@@ -2,15 +2,15 @@
 console.log("DEBUG: main.js - Script principal INICIADO.");
 
 // Inicialización de Supabase (para SDK LOCAL ./supabase.js)
-// Asegúrate que SUPABASE_URL y SUPABASE_ANON_KEY vienen de config.js y están definidos
+// Asegúrate que X_SUPABASE_URL y X_SUPABASE_ANON_KEY vienen de config.js y están definidos
 console.log("DEBUG: main.js - Verificando SDK global 'supabase'. typeof window.supabase:", typeof window.supabase);
 if (typeof window.supabase !== 'undefined' &&
     typeof window.supabase.createClient === 'function' &&
-    typeof SUPABASE_URL !== 'undefined' && typeof SUPABASE_ANON_KEY !== 'undefined' &&
-    SUPABASE_URL && SUPABASE_ANON_KEY && SUPABASE_URL !== 'TU_SUPABASE_URL') {
+    typeof X_SUPABASE_URL !== 'undefined' && typeof X_SUPABASE_ANON_KEY !== 'undefined' &&
+    X_SUPABASE_URL && X_SUPABASE_ANON_KEY && X_SUPABASE_URL !== 'TU_SUPABASE_URL') {
     try {
         // supabaseClientInstance se declara en globals.js y se asigna aquí
-        supabaseClientInstance = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+        supabaseClientInstance = window.supabase.createClient(X_SUPABASE_URL, X_SUPABASE_ANON_KEY);
         console.log('DEBUG: main.js - Instancia del cliente Supabase creada exitosamente desde SDK LOCAL.');
     } catch (e) {
         console.error('DEBUG: main.js - Error al inicializar Supabase con createClient (SDK local):', e);
@@ -25,8 +25,8 @@ if (typeof window.supabase !== 'undefined' &&
     let errorMsg = 'DEBUG: main.js - Error: Supabase no pudo inicializarse (SDK local). ';
     if (typeof window.supabase === 'undefined') errorMsg += 'SDK (window.supabase) no cargado o no encontrado. ';
     else if (typeof window.supabase.createClient !== 'function') errorMsg += 'SDK (window.supabase) cargado pero createClient no es una función. ';
-    if (typeof SUPABASE_URL === 'undefined' || !SUPABASE_URL) errorMsg += 'SUPABASE_URL no definida. ';
-    if (typeof SUPABASE_ANON_KEY === 'undefined' || !SUPABASE_ANON_KEY) errorMsg += 'SUPABASE_ANON_KEY no definida. ';
+    if (typeof X_SUPABASE_URL === 'undefined' || !X_SUPABASE_URL) errorMsg += 'X_SUPABASE_URL no definida. ';
+    if (typeof X_SUPABASE_ANON_KEY === 'undefined' || !X_SUPABASE_ANON_KEY) errorMsg += 'X_SUPABASE_ANON_KEY no definida. ';
     console.error(errorMsg);
     const cpError = document.getElementById('contenedor-principal');
     if (cpError) {

--- a/test_app_test.js
+++ b/test_app_test.js
@@ -14,8 +14,14 @@ function updateStatus(message, type = "info") {
 
 updateStatus("Verificando SDK de Supabase...", "info");
 
-const SUPABASE_URL = 'https://srqdgsgxkxfiveynxkwt.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNycWRnc2d4a3hmaXZleW54a3d0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg1Mjg2MjUsImV4cCI6MjA2NDEwNDYyNX0.xenXPUm17l0LvbvUk0fsbVik3y5uKP3ADwaVN5BcKGY';
+const X_SUPABASE_URL =
+    (typeof window !== 'undefined' && window.X_SUPABASE_URL) ||
+    (typeof process !== 'undefined' && process.env.X_SUPABASE_URL) ||
+    '';
+const X_SUPABASE_ANON_KEY =
+    (typeof window !== 'undefined' && window.X_SUPABASE_ANON_KEY) ||
+    (typeof process !== 'undefined' && process.env.X_SUPABASE_ANON_KEY) ||
+    '';
 
 let supabaseClientInstance = null; // Renombrada para evitar confusión con el global del SDK
 
@@ -33,7 +39,7 @@ function checkAndInitializeSupabase() {
         updateStatus("SDK encontrado. Inicializando Supabase...", "info");
         try {
             // Usamos el objeto global del SDK para crear el cliente
-            supabaseClientInstance = sdkGlobalObject.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+            supabaseClientInstance = sdkGlobalObject.createClient(X_SUPABASE_URL, X_SUPABASE_ANON_KEY);
             
             console.log('app_test.js: Instancia del cliente Supabase creada:', supabaseClientInstance);
 

--- a/test_index.html
+++ b/test_index.html
@@ -12,5 +12,8 @@
     <h1>Prueba de Conexión LibroVa con Supabase</h1>
     <div id="status">Inicializando prueba...</div>
 
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script> <script src="app_test.js"></script>   </body>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="js/config.js"></script>
+    <script src="app_test.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- prevent accidental commits of user secrets
- read Supabase credentials from env variables or local `config.js`
- provide `config.sample.js` for local setup
- update test page to include config
- rename env vars to `X_SUPABASE_URL` and `X_SUPABASE_ANON_KEY`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684802a80da88329b60c162ad37307b7