### PR TITLE
Fix DOM creation in gestion libros

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -252,9 +252,12 @@ async function renderizarDetallesGestionLibro(libroId) {
             img.style.borderRadius = '4px';
             img.style.marginBottom = '15px';
             const pId = document.createElement('p');
-            pId.innerHTML = `<strong>ID:</strong> ${libro.id}`;
+            pId.appendChild(document.createElement('strong')).textContent = 'ID:';
+            pId.append(` ${libro.id}`);
+
             const pEstado = document.createElement('p');
-            pEstado.innerHTML = `<strong>Estado:</strong> ${libro.estado}`;
+            pEstado.appendChild(document.createElement('strong')).textContent = 'Estado:';
+            pEstado.append(` ${libro.estado}`);
             infoDiv.appendChild(h4);
             infoDiv.appendChild(img);
             infoDiv.appendChild(pId);


### PR DESCRIPTION
## Summary
- avoid innerHTML when rendering gestion libro details

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848171b59b08329895bd3fe49d96d8b