### PR TITLE
Update return book update query

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -52,13 +52,15 @@ async function marcarLibroComoDevuelto(libroId) {
             .single();
         if (fetchErr) throw fetchErr;
 
-        const { error, count } = await supabaseClientInstance.from('libros')
+        const { data, error } = await supabaseClientInstance
+            .from('libros')
             .update({ estado: 'disponible', esta_con_usuario_id: null, fecha_limite_devolucion: null })
             .eq('id', libroId)
             .eq('propietario_id', currentUser.id)
-            .eq('estado', 'prestado');
+            .eq('estado', 'prestado')
+            .select();
         if (error) throw error;
-        if (count === 0 || count === null) {
+        if (!data || data.length === 0) {
             console.warn(`DEBUG: libros_ops.js - No se actualizó libro ID: ${libroId} a devuelto.`);
         } else {
             console.log(`DEBUG: libros_ops.js - Libro ID: ${libroId} marcado como 'disponible'.`);


### PR DESCRIPTION
## Summary
- update `marcarLibroComoDevuelto` query to always return rows
- warn if no rows updated

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68482d2161908329ba2180b2f5ba5a0a