### PR TITLE
Add basic admin panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <script src="js/auth.js"></script>
     <script src="js/libros_ops.js"></script>
     <script src="js/libros_ui.js"></script>
+    <script src="js/admin_ops.js"></script>
     <script src="js/notificaciones.js"></script>
     <script src="js/ui_render_views.js"></script>
     <script src="js/main.js"></script>

--- a/js/admin_ops.js
+++ b/js/admin_ops.js
@@ -1,0 +1,130 @@
+// js/admin_ops.js
+console.log("DEBUG: admin_ops.js - Cargado.");
+
+async function listarLibrosAdmin() {
+    if (!supabaseClientInstance) return [];
+    const { data, error } = await supabaseClientInstance.from('libros').select('*').order('id', { ascending: true });
+    if (error) { console.error('DEBUG: admin_ops.js - Error listar libros:', error); return []; }
+    return data || [];
+}
+
+async function crearLibroAdmin(libro) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('libros').insert(libro).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error crear libro:', error); return null; }
+    return data;
+}
+
+async function editarLibroAdmin(id, campos) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('libros').update(campos).eq('id', id).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error editar libro:', error); return null; }
+    return data;
+}
+
+async function eliminarLibroAdmin(id) {
+    if (!supabaseClientInstance) return;
+    const { error } = await supabaseClientInstance.from('libros').delete().eq('id', id);
+    if (error) console.error('DEBUG: admin_ops.js - Error eliminar libro:', error);
+}
+
+async function listarUsuariosAdmin() {
+    if (!supabaseClientInstance) return [];
+    const { data, error } = await supabaseClientInstance.from('usuarios').select('*').order('id', { ascending: true });
+    if (error) { console.error('DEBUG: admin_ops.js - Error listar usuarios:', error); return []; }
+    return data || [];
+}
+
+async function crearUsuarioAdmin(usuario) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('usuarios').insert(usuario).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error crear usuario:', error); return null; }
+    return data;
+}
+
+async function editarUsuarioAdmin(id, campos) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('usuarios').update(campos).eq('id', id).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error editar usuario:', error); return null; }
+    return data;
+}
+
+async function eliminarUsuarioAdmin(id) {
+    if (!supabaseClientInstance) return;
+    const { error } = await supabaseClientInstance.from('usuarios').delete().eq('id', id);
+    if (error) console.error('DEBUG: admin_ops.js - Error eliminar usuario:', error);
+}
+
+async function listarSolicitudesAdmin() {
+    if (!supabaseClientInstance) return [];
+    const { data, error } = await supabaseClientInstance.from('solicitudes_prestamo').select('*').order('id', { ascending: true });
+    if (error) { console.error('DEBUG: admin_ops.js - Error listar solicitudes:', error); return []; }
+    return data || [];
+}
+
+async function crearSolicitudAdmin(solicitud) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('solicitudes_prestamo').insert(solicitud).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error crear solicitud:', error); return null; }
+    return data;
+}
+
+async function editarSolicitudAdmin(id, campos) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('solicitudes_prestamo').update(campos).eq('id', id).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error editar solicitud:', error); return null; }
+    return data;
+}
+
+async function eliminarSolicitudAdmin(id) {
+    if (!supabaseClientInstance) return;
+    const { error } = await supabaseClientInstance.from('solicitudes_prestamo').delete().eq('id', id);
+    if (error) console.error('DEBUG: admin_ops.js - Error eliminar solicitud:', error);
+}
+
+async function listarNotificacionesAdmin() {
+    if (!supabaseClientInstance) return [];
+    const { data, error } = await supabaseClientInstance.from('notificaciones').select('*').order('id', { ascending: true });
+    if (error) { console.error('DEBUG: admin_ops.js - Error listar notificaciones:', error); return []; }
+    return data || [];
+}
+
+async function crearNotificacionAdmin(notificacion) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('notificaciones').insert(notificacion).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error crear notificación:', error); return null; }
+    return data;
+}
+
+async function editarNotificacionAdmin(id, campos) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('notificaciones').update(campos).eq('id', id).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error editar notificación:', error); return null; }
+    return data;
+}
+
+async function eliminarNotificacionAdmin(id) {
+    if (!supabaseClientInstance) return;
+    const { error } = await supabaseClientInstance.from('notificaciones').delete().eq('id', id);
+    if (error) console.error('DEBUG: admin_ops.js - Error eliminar notificación:', error);
+}
+
+window.listarLibrosAdmin = listarLibrosAdmin;
+window.crearLibroAdmin = crearLibroAdmin;
+window.editarLibroAdmin = editarLibroAdmin;
+window.eliminarLibroAdmin = eliminarLibroAdmin;
+
+window.listarUsuariosAdmin = listarUsuariosAdmin;
+window.crearUsuarioAdmin = crearUsuarioAdmin;
+window.editarUsuarioAdmin = editarUsuarioAdmin;
+window.eliminarUsuarioAdmin = eliminarUsuarioAdmin;
+
+window.listarSolicitudesAdmin = listarSolicitudesAdmin;
+window.crearSolicitudAdmin = crearSolicitudAdmin;
+window.editarSolicitudAdmin = editarSolicitudAdmin;
+window.eliminarSolicitudAdmin = eliminarSolicitudAdmin;
+
+window.listarNotificacionesAdmin = listarNotificacionesAdmin;
+window.crearNotificacionAdmin = crearNotificacionAdmin;
+window.editarNotificacionAdmin = editarNotificacionAdmin;
+window.eliminarNotificacionAdmin = eliminarNotificacionAdmin;

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -97,6 +97,7 @@ function renderizarVistaBienvenida() {
         </div>
         <div id="vista-anadir-libro" class="vista"><h3>Añadir Nuevo Libro</h3><form id="form-anadir-libro"><label for="libro-titulo">Título del Libro:</label><input type="text" id="libro-titulo" required><br><br><label for="libro-foto">Foto de la Portada:</label><input type="file" id="libro-foto" accept="image/*" capture="environment" required><br><br><img id="libro-foto-preview" src="#" alt="Vista previa de la portada" style="max-width: 200px; max-height: 200px; display: none; margin-bottom:15px;"><br><button type="submit">Guardar Libro</button><button type="button" id="btn-volver-dashboard-desde-anadir">Cancelar y Volver al Dashboard</button></form></div>
         <div id="vista-gestionar-libro-propio" class="vista"><h3>Gestionar Mi Libro</h3><p>Aquí podrás editar o eliminar tu libro que esté disponible.</p><div id="detalles-libro-gestion"></div><button type="button" id="btn-volver-dashboard-desde-gestion">Volver al Dashboard</button></div>
+        <div id="vista-admin-panel" class="vista"></div>
     `;
     const selectAvatarRegistro = document.getElementById('alumno-avatar-registro');
     if (selectAvatarRegistro) {
@@ -300,10 +301,12 @@ function renderizarDashboard() {
 
     const nombreUsuario = currentUser.rol === 'admin' ? currentUser.email : currentUser.nickname;
     const reputacionMostrar = (currentUser.reputacion !== undefined && currentUser.reputacion !== null) ? currentUser.reputacion : 0;
+    const adminBtn = currentUser.rol === 'admin' ? '<button id="btn-ir-admin-panel" class="boton-accion-base gestionar">Panel Admin</button><hr>' : '';
     dashboardView.innerHTML = `
         <h2 id="titulo-dashboard"></h2>
         <p id="reputacion-dashboard"></p>
         <button id="btn-ir-anadir-libro" class="boton-accion-base cargar">Cargar Libro</button>
+        ${adminBtn}
         <hr>
         <div class="seccion-dashboard">
             <h3>Novedades y Decisiones Pendientes</h3>
@@ -328,6 +331,8 @@ function renderizarDashboard() {
 
     const btnIrAnadirLibro = document.getElementById('btn-ir-anadir-libro');
     if (btnIrAnadirLibro) { btnIrAnadirLibro.onclick = () => cambiarVista('vista-dashboard', 'vista-anadir-libro');}
+    const btnIrAdminPanel = document.getElementById('btn-ir-admin-panel');
+    if (btnIrAdminPanel) btnIrAdminPanel.onclick = renderizarPanelAdmin;
     console.log("DEBUG: ui_render_views.js - HTML de Dashboard completo inyectado.");
 
     const vistaActivaPrevia = document.querySelector('.vista.activa');
@@ -484,6 +489,214 @@ async function renderizarVistaRanking() {
     }
 }
 
+async function renderizarPanelAdmin() {
+    const vistaActual = document.querySelector('.vista.activa');
+    const vista = document.getElementById('vista-admin-panel');
+    if (!vista) return;
+    vista.innerHTML = `
+        <h3>Panel Administrador</h3>
+        <div class="seccion-dashboard">
+            <h4>Libros</h4>
+            <div id="admin-lista-libros">Cargando...</div>
+            <form id="form-admin-libro">
+                <input type="text" id="admin-libro-titulo" placeholder="Título">
+                <button type="submit" class="boton-accion-base submit">Crear Libro</button>
+            </form>
+        </div>
+        <div class="seccion-dashboard">
+            <h4>Usuarios</h4>
+            <div id="admin-lista-usuarios">Cargando...</div>
+            <form id="form-admin-usuario">
+                <input type="text" id="admin-usuario-nickname" placeholder="Nickname">
+                <button type="submit" class="boton-accion-base submit">Crear Usuario</button>
+            </form>
+        </div>
+        <div class="seccion-dashboard">
+            <h4>Solicitudes</h4>
+            <div id="admin-lista-solicitudes">Cargando...</div>
+        </div>
+        <div class="seccion-dashboard">
+            <h4>Notificaciones</h4>
+            <div id="admin-lista-notificaciones">Cargando...</div>
+        </div>
+        <button type="button" id="btn-volver-dashboard-desde-admin" class="boton-accion-base gestionar">Volver al Dashboard</button>
+    `;
+    cambiarVista(vistaActual ? vistaActual.id : null, 'vista-admin-panel');
+
+    await cargarDatosPanelAdmin();
+
+    document.getElementById('form-admin-libro').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const t = document.getElementById('admin-libro-titulo').value.trim();
+        if (t) {
+            await crearLibroAdmin({ titulo: t });
+            renderizarPanelAdmin();
+        }
+    });
+
+    document.getElementById('form-admin-usuario').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const n = document.getElementById('admin-usuario-nickname').value.trim();
+        if (n) {
+            await crearUsuarioAdmin({ nickname: n });
+            renderizarPanelAdmin();
+        }
+    });
+
+    document.getElementById('btn-volver-dashboard-desde-admin').onclick = renderizarDashboard;
+}
+
+async function cargarDatosPanelAdmin() {
+    const divLibros = document.getElementById('admin-lista-libros');
+    const libros = await listarLibrosAdmin();
+    divLibros.innerHTML = '';
+    libros.forEach(l => {
+        const item = document.createElement('div');
+        item.className = 'item-lista-libro';
+        const detalles = document.createElement('div');
+        detalles.className = 'detalles';
+        detalles.textContent = `[${l.id}] ${l.titulo}`;
+        item.appendChild(detalles);
+        const acciones = document.createElement('div');
+        acciones.className = 'acciones';
+        const bE = document.createElement('button');
+        bE.className = 'boton-accion-base gestionar';
+        bE.textContent = 'Editar';
+        bE.onclick = async () => {
+            const nuevo = prompt('Nuevo título', l.titulo);
+            if (nuevo !== null) {
+                await editarLibroAdmin(l.id, { titulo: nuevo });
+                renderizarPanelAdmin();
+            }
+        };
+        const bD = document.createElement('button');
+        bD.className = 'boton-accion-base eliminar';
+        bD.textContent = 'Eliminar';
+        bD.onclick = async () => {
+            if (confirm('¿Eliminar libro?')) {
+                await eliminarLibroAdmin(l.id);
+                renderizarPanelAdmin();
+            }
+        };
+        acciones.appendChild(bE);
+        acciones.appendChild(bD);
+        item.appendChild(acciones);
+        divLibros.appendChild(item);
+    });
+
+    const divUsuarios = document.getElementById('admin-lista-usuarios');
+    const usuarios = await listarUsuariosAdmin();
+    divUsuarios.innerHTML = '';
+    usuarios.forEach(u => {
+        const item = document.createElement('div');
+        item.className = 'item-lista-libro';
+        const detalles = document.createElement('div');
+        detalles.className = 'detalles';
+        detalles.textContent = `[${u.id}] ${u.nickname}`;
+        item.appendChild(detalles);
+        const acciones = document.createElement('div');
+        acciones.className = 'acciones';
+        const bE = document.createElement('button');
+        bE.className = 'boton-accion-base gestionar';
+        bE.textContent = 'Editar';
+        bE.onclick = async () => {
+            const nuevo = prompt('Nuevo nickname', u.nickname);
+            if (nuevo !== null) {
+                await editarUsuarioAdmin(u.id, { nickname: nuevo });
+                renderizarPanelAdmin();
+            }
+        };
+        const bD = document.createElement('button');
+        bD.className = 'boton-accion-base eliminar';
+        bD.textContent = 'Eliminar';
+        bD.onclick = async () => {
+            if (confirm('¿Eliminar usuario?')) {
+                await eliminarUsuarioAdmin(u.id);
+                renderizarPanelAdmin();
+            }
+        };
+        acciones.appendChild(bE);
+        acciones.appendChild(bD);
+        item.appendChild(acciones);
+        divUsuarios.appendChild(item);
+    });
+
+    const divSol = document.getElementById('admin-lista-solicitudes');
+    const solicitudes = await listarSolicitudesAdmin();
+    divSol.innerHTML = '';
+    solicitudes.forEach(s => {
+        const item = document.createElement('div');
+        item.className = 'item-lista-libro';
+        const detalles = document.createElement('div');
+        detalles.className = 'detalles';
+        detalles.textContent = `[${s.id}] libro ${s.libro_id} - ${s.estado_solicitud}`;
+        item.appendChild(detalles);
+        const acciones = document.createElement('div');
+        acciones.className = 'acciones';
+        const bE = document.createElement('button');
+        bE.className = 'boton-accion-base gestionar';
+        bE.textContent = 'Editar';
+        bE.onclick = async () => {
+            const nuevo = prompt('Nuevo estado', s.estado_solicitud);
+            if (nuevo !== null) {
+                await editarSolicitudAdmin(s.id, { estado_solicitud: nuevo });
+                renderizarPanelAdmin();
+            }
+        };
+        const bD = document.createElement('button');
+        bD.className = 'boton-accion-base eliminar';
+        bD.textContent = 'Eliminar';
+        bD.onclick = async () => {
+            if (confirm('¿Eliminar solicitud?')) {
+                await eliminarSolicitudAdmin(s.id);
+                renderizarPanelAdmin();
+            }
+        };
+        acciones.appendChild(bE);
+        acciones.appendChild(bD);
+        item.appendChild(acciones);
+        divSol.appendChild(item);
+    });
+
+    const divNot = document.getElementById('admin-lista-notificaciones');
+    const notas = await listarNotificacionesAdmin();
+    divNot.innerHTML = '';
+    notas.forEach(n => {
+        const item = document.createElement('div');
+        item.className = 'item-lista-libro';
+        const detalles = document.createElement('div');
+        detalles.className = 'detalles';
+        detalles.textContent = `[${n.id}] ${n.mensaje}`;
+        item.appendChild(detalles);
+        const acciones = document.createElement('div');
+        acciones.className = 'acciones';
+        const bE = document.createElement('button');
+        bE.className = 'boton-accion-base gestionar';
+        bE.textContent = 'Editar';
+        bE.onclick = async () => {
+            const nuevo = prompt('Nuevo mensaje', n.mensaje);
+            if (nuevo !== null) {
+                await editarNotificacionAdmin(n.id, { mensaje: nuevo });
+                renderizarPanelAdmin();
+            }
+        };
+        const bD = document.createElement('button');
+        bD.className = 'boton-accion-base eliminar';
+        bD.textContent = 'Eliminar';
+        bD.onclick = async () => {
+            if (confirm('¿Eliminar notificación?')) {
+                await eliminarNotificacionAdmin(n.id);
+                renderizarPanelAdmin();
+            }
+        };
+        acciones.appendChild(bE);
+        acciones.appendChild(bD);
+        item.appendChild(acciones);
+        divNot.appendChild(item);
+    });
+}
+
 window.renderizarVistaRanking = renderizarVistaRanking;
 window.renderizarListaNotificaciones = renderizarListaNotificaciones;
 window.renderizarNovedadesPendientes = renderizarNovedadesPendientes;
+window.renderizarPanelAdmin = renderizarPanelAdmin;


### PR DESCRIPTION
## Summary
- create **admin_ops.js** with CRUD helpers for books, users, loans and notifications
- inject new script in `index.html`
- render new admin panel and hook from dashboard
- enable admin button and panel events in UI

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_684887cb9cf08329a0814cdf3c216c1c