### PR TITLE
Add dismiss button for notifications

### DIFF
--- a/js/notificaciones.js
+++ b/js/notificaciones.js
@@ -46,6 +46,20 @@ window.agregarNotificacion = agregarNotificacion;
 window.cargarNotificacionesUsuario = cargarNotificacionesUsuario;
 window.marcarNotificacionesLeidas = marcarNotificacionesLeidas;
 
+async function eliminarNotificacion(id) {
+    if (!supabaseClientInstance) return;
+    try {
+        await supabaseClientInstance
+            .from('notificaciones')
+            .delete()
+            .eq('id', id);
+    } catch (e) {
+        console.error('DEBUG: notificaciones.js - Error al eliminar notificación:', e);
+    }
+}
+
+window.eliminarNotificacion = eliminarNotificacion;
+
 async function refrescarNotificaciones() {
     if (!currentUser) return;
     notificaciones = await cargarNotificacionesUsuario(currentUser.id);

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -385,6 +385,17 @@ function renderizarListaNotificaciones(divId, notas) {
         span.textContent = new Date(n.created_at).toLocaleDateString('es-AR');
 
         item.appendChild(span);
+
+        const btnVisto = document.createElement('button');
+        btnVisto.className = 'boton-visto-notificacion';
+        btnVisto.textContent = 'Visto';
+        btnVisto.onclick = async () => {
+            await eliminarNotificacion(n.id);
+            await refrescarNotificaciones();
+            renderizarListaNotificaciones(divId, notificaciones);
+        };
+        item.appendChild(btnVisto);
+
         div.appendChild(item);
     }
 }
@@ -413,6 +424,17 @@ function renderizarNovedadesPendientes(divId, notas, solicitudes) {
             span.style.color = '#4A5568';
             span.textContent = new Date(n.created_at).toLocaleDateString('es-AR');
             item.appendChild(span);
+
+            const btnVisto = document.createElement('button');
+            btnVisto.className = 'boton-visto-notificacion';
+            btnVisto.textContent = 'Visto';
+            btnVisto.onclick = async () => {
+                await eliminarNotificacion(n.id);
+                await refrescarNotificaciones();
+                renderizarNovedadesPendientes(divId, notificaciones, solicitudes);
+            };
+            item.appendChild(btnVisto);
+
             div.appendChild(item);
         });
     }

--- a/style.css
+++ b/style.css
@@ -233,6 +233,19 @@ form button[type="button"]:hover {
 .lista-notificaciones { display: flex; flex-direction: column; gap: 10px; }
 .item-notificacion { background-color: #edf2f7; padding: 8px 12px; border-radius: 5px; }
 .item-notificacion.nueva { font-weight: bold; }
+.boton-visto-notificacion {
+    background-color: #E2E8F0;
+    color: #2D3748;
+    border: none;
+    border-radius: 4px;
+    padding: 3px 8px;
+    font-size: 0.75em;
+    margin-left: 8px;
+    cursor: pointer;
+}
+.boton-visto-notificacion:hover {
+    background-color: #CBD5E0;
+}
 .lista-novedades { display: flex; flex-direction: column; gap: 15px; }
 .item-novedad { display: flex; align-items: flex-start; }
 .item-novedad .icono-novedad { margin-right: 8px; }


### PR DESCRIPTION
## Summary
- add helper to delete notifications via Supabase
- attach delete function to window
- add "Visto" actions on notifications lists
- small grey button styling for "Visto"

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68499ac25e3083298ccc2501fa102750