### PR TITLE
Improve mobile display of dashboard lists

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -127,6 +127,7 @@ function renderizarListaDashboard(divId, libros, tipoLista) {
     const div = document.getElementById(divId); if (!div) { console.error(`DEBUG: ui_render_views.js - Div ${divId} no encontrado.`); return; }
     div.innerHTML = '';
     if (!libros || libros.length === 0) { div.innerHTML = `<p>No tienes libros en esta categoría.</p>`; return; }
+    const isSmallScreen = window.innerWidth <= 480;
     libros.forEach(libro => {
         const item = document.createElement('div');
         item.className = 'item-lista-libro';
@@ -147,20 +148,34 @@ function renderizarListaDashboard(divId, libros, tipoLista) {
         const fechaDev = libro.fecha_limite_devolucion ? new Date(libro.fecha_limite_devolucion).toLocaleDateString('es-AR', { day: '2-digit', month: '2-digit', year: 'numeric' }) : 'N/A';
         if (tipoLista === 'prestadosPorMi') {
             const prestatario = libro.prestado_a ? libro.prestado_a.nickname : 'Alguien';
-            const span1 = document.createElement('span');
-            span1.textContent = `Prestado a: ${prestatario}`;
-            const span2 = document.createElement('span');
-            span2.textContent = `Devolver el: ${fechaDev}`;
-            detalles.appendChild(span1);
-            detalles.appendChild(span2);
+            if (isSmallScreen) {
+                const span = document.createElement('span');
+                span.textContent = `Prestado a: ${prestatario} - Dev: ${fechaDev}`;
+                span.style.fontSize = '0.75em';
+                detalles.appendChild(span);
+            } else {
+                const span1 = document.createElement('span');
+                span1.textContent = `Prestado a: ${prestatario}`;
+                const span2 = document.createElement('span');
+                span2.textContent = `Devolver el: ${fechaDev}`;
+                detalles.appendChild(span1);
+                detalles.appendChild(span2);
+            }
         } else if (tipoLista === 'prestadosAMi') {
             const dueno = libro.propietario ? libro.propietario.nickname : 'Desconocido';
-            const span1 = document.createElement('span');
-            span1.textContent = `Dueño: ${dueno}`;
-            const span2 = document.createElement('span');
-            span2.textContent = `Devolver el: ${fechaDev}`;
-            detalles.appendChild(span1);
-            detalles.appendChild(span2);
+            if (isSmallScreen) {
+                const span = document.createElement('span');
+                span.textContent = `Due\u00f1o: ${dueno} - Dev: ${fechaDev}`;
+                span.style.fontSize = '0.75em';
+                detalles.appendChild(span);
+            } else {
+                const span1 = document.createElement('span');
+                span1.textContent = `Due\u00f1o: ${dueno}`;
+                const span2 = document.createElement('span');
+                span2.textContent = `Devolver el: ${fechaDev}`;
+                detalles.appendChild(span1);
+                detalles.appendChild(span2);
+            }
         }
         item.appendChild(detalles);
 

--- a/style.css
+++ b/style.css
@@ -343,6 +343,34 @@ form button[type="button"]:hover {
 
 @media (max-width: 480px) {
     .libro-card { width: 100%; }
+    .item-lista-libro, .item-solicitud {
+        display: grid;
+        grid-template-columns: 60px 1fr;
+        grid-template-areas:
+            "img detalles"
+            "acciones acciones";
+        padding: 8px;
+        text-align: left;
+    }
+    .item-lista-libro img.thumbnail, .item-solicitud img.thumbnail {
+        grid-area: img;
+        margin-right: 0;
+    }
+    .item-lista-libro .detalles, .item-solicitud .detalles {
+        grid-area: detalles;
+    }
+    .item-lista-libro .acciones, .item-solicitud .acciones {
+        grid-area: acciones;
+        flex-direction: row;
+        justify-content: center;
+        margin-left: 0;
+        margin-top: 5px;
+        gap: 5px;
+    }
+    .item-lista-libro .acciones button, .item-solicitud .acciones button {
+        width: auto;
+        flex: 1 1 auto;
+    }
 }
 
 .lista-ranking { list-style: decimal; padding-left: 20px; }


### PR DESCRIPTION
## Summary
- apply compact grid layout for list items below 480px
- combine request/date information on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68499f7330c08329a5dcd0f657d936f4