### PR TITLE
Improve libro-card layout

### DIFF
--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -61,15 +61,20 @@ async function cargarYMostrarLibros() {
                 titulo.textContent = libro.titulo;
                 card.appendChild(titulo);
 
-                const propietario = document.createElement('p');
+                const meta = document.createElement('div');
+                meta.className = 'libro-meta';
+
+                const propietario = document.createElement('span');
                 propietario.className = 'libro-propietario';
                 propietario.textContent = `Dueño: ${propietarioNombre}`;
-                card.appendChild(propietario);
+                meta.appendChild(propietario);
 
-                const estado = document.createElement('p');
+                const estado = document.createElement('span');
                 estado.className = 'libro-estado';
                 estado.textContent = `Estado: ${libro.estado}`;
-                card.appendChild(estado);
+                meta.appendChild(estado);
+
+                card.appendChild(meta);
 
                 if (libro.estado === 'prestado') {
                     const prestamoInfo = document.createElement('p');

--- a/style.css
+++ b/style.css
@@ -283,20 +283,21 @@ form button[type="button"]:hover {
 /* Tarjetas de Libros (para la lista general "Libros Disponibles") */
 .libro-card {
     background-color: rgba(255, 255, 255, 0.98); border: 1px solid #e2e8f0; 
-    border-radius: 8px; padding: 15px; margin: 10px; width: 190px; min-height: 340px; 
+    border-radius: 8px; padding: 10px; margin: 8px; width: 190px; min-height: 300px; 
     display: flex; flex-direction: column; justify-content: space-between;
     box-shadow: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06); 
     text-align: center; transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
 }
 .libro-card:hover { transform: translateY(-3px); box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05); }
-.libro-portada { width: 100%; height: 200px; object-fit: cover; border-radius: 4px; margin-bottom: 12px; background-color: #e2e8f0; }
+.libro-portada { width: 100%; height: 180px; object-fit: cover; border-radius: 4px; margin-bottom: 8px; background-color: #e2e8f0; }
 .libro-titulo {
     font-size: 1.05em; font-weight: 600; color: #1A202C; margin-bottom: 8px;
     display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
     overflow: hidden; text-overflow: ellipsis; height: 2.5em; line-height: 1.25em;
 }
-.libro-propietario, .libro-estado { font-size: 0.8em; color: #4A5568; margin-bottom: 8px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.libro-info-prestamo { font-size: 0.8em; color: #c05621; background-color: #fffaf0; padding: 6px; border-radius: 4px; margin-top: 5px; margin-bottom: 8px; line-height: 1.3; border: 1px dashed #dd6b20; }
+.libro-propietario, .libro-estado { font-size: 0.8em; color: #4A5568; margin-bottom: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.libro-meta { display:flex; justify-content:space-between; align-items:center; gap:4px; margin-bottom:6px; }
+.libro-info-prestamo { font-size: 0.8em; color: #c05621; background-color: #fffaf0; padding: 6px; border-radius: 4px; margin-top: 5px; margin-bottom: 6px; line-height: 1.3; border: 1px dashed #dd6b20; }
 .libro-card button { margin-top: auto; width: 100%; box-sizing: border-box; }
 /* Los botones btn-pedir-prestado, btn-gestionar-libro, btn-marcar-devuelto en .libro-card USARÁN .boton-accion-base y su modificador de color */
 
@@ -342,6 +343,7 @@ form button[type="button"]:hover {
 }
 
 @media (max-width: 480px) {
+    .libro-meta { flex-direction: column; align-items: flex-start; }
     .libro-card { width: 100%; }
 }
 


### PR DESCRIPTION
## Summary
- tweak `.libro-card` padding, margin and image height
- add `.libro-meta` wrapper for owner and status
- render owner and status in `.libro-meta`
- adjust small-screen layout

## Testing
- `node --check js/libros_ui.js`

------
https://chatgpt.com/codex/tasks/task_e_68499f74cd2c832982e9497072eb27d2