### PR TITLE
Refresh pending requests on response

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -131,10 +131,9 @@ async function responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, p
     } catch (err) {
         console.error("DEBUG: libros_ops.js - Error procesando solicitud:", err);
     } finally {
-        cargarSolicitudesRecibidas(currentUser.id).then(s => {
-            renderizarNovedadesPendientes("lista-novedades", notificaciones, s);
-            asignarEventListenersLibros();
-        });
+        const solicitudes = await cargarSolicitudesRecibidas(currentUser.id);
+        renderizarNovedadesPendientes("lista-novedades", notificaciones, solicitudes);
+        asignarEventListenersLibros();
         cargarYMostrarLibros();
         recargarSeccionesPrestamosDashboard();
         actualizarMenuPrincipal();

--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -127,7 +127,7 @@ function asignarEventListenersLibros() {
     document.addEventListener("click", delegarClicksLibros);
 }
 
-function delegarClicksLibros(event) {
+async function delegarClicksLibros(event) {
     if (event.target.closest("#lista-libros-disponibles .btn-pedir-prestamo")) {
         const libroCard = event.target.closest(".libro-card");
         if (!currentUser) { console.error("Login requerido"); renderizarVistaBienvenida(); return; }
@@ -169,7 +169,8 @@ function delegarClicksLibros(event) {
         const solicitanteNicknameElement = itemSolicitud.querySelector(".detalles span:nth-child(2)");
         const solicitanteNickname = solicitanteNicknameElement ? solicitanteNicknameElement.textContent.replace("Solicitado por: ", "").trim() : "Alguien";
         console.log(`DEBUG: libros_ui.js - Aceptar solicitud ID: ${solicitudId}`);
-        responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, propietarioId, "aceptada", libroTitulo, solicitanteNickname);
+        await responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, propietarioId, "aceptada", libroTitulo, solicitanteNickname);
+        if (itemSolicitud) itemSolicitud.remove();
     } else if (event.target.closest("#lista-novedades .btn-rechazar-solicitud")) {
         const itemSolicitud = event.target.closest(".item-solicitud");
         const solicitudId = itemSolicitud.dataset.solicitudId;
@@ -179,7 +180,8 @@ function delegarClicksLibros(event) {
         const solicitanteNicknameElement = itemSolicitud.querySelector(".detalles span:nth-child(2)");
         const solicitanteNickname = solicitanteNicknameElement ? solicitanteNicknameElement.textContent.replace("Solicitado por: ", "").trim() : "Alguien";
         console.log(`DEBUG: libros_ui.js - Rechazar solicitud ID: ${solicitudId}`);
-        responderSolicitudPrestamo(solicitudId, null, solicitanteId, propietarioId, "rechazada", libroTitulo, solicitanteNickname);
+        await responderSolicitudPrestamo(solicitudId, null, solicitanteId, propietarioId, "rechazada", libroTitulo, solicitanteNickname);
+        if (itemSolicitud) itemSolicitud.remove();
 
     }
 }


### PR DESCRIPTION
## Summary
- make `delegarClicksLibros` async and await `responderSolicitudPrestamo`
- remove request item after acceptance or rejection
- await `cargarSolicitudesRecibidas` inside `responderSolicitudPrestamo`

## Testing
- `node --check js/libros_ui.js`
- `node --check js/libros_ops.js`

------
https://chatgpt.com/codex/tasks/task_e_684ad143ad708329996c4fb652dda0b3