### PR TITLE
Fix missing async keyword in recargarSeccionesPrestamosDashboard

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -178,7 +178,7 @@ async function handleAnadirLibroSubmit(event) {
     } finally { submitButton.disabled = false; submitButton.textContent = 'Guardar Libro'; }
 }
 
-function recargarSeccionesPrestamosDashboard() {
+async function recargarSeccionesPrestamosDashboard() {
     if (!currentUser) return;
     if (document.getElementById('mis-libros-en-prestamo')) {
         cargarMisLibrosEnPrestamo(currentUser.id).then(libros => {


### PR DESCRIPTION
## Summary
- fix syntax error so `recargarSeccionesPrestamosDashboard` is an async function

## Testing
- `node -c js/libros_ops.js`
- `for f in js/*.js; do node -c "$f"; done`
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684ad61aaed48329bb4c9f39df0f2a7d