### PR TITLE
Refactor loan tracking via new prestamos table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
 # LibroVa
 
 
-LibroVa es una sencilla aplicación web pensada para que estudiantes compartan y pidan prestados libros entre compañeros. Utiliza **Supabase** como plataforma backend para el manejo de usuarios y del catálogo de libros.
+LibroVa es una sencilla aplicación web pensada para que estudiantes compartan y piden prestados libros entre compañeros. Utiliza **Supabase** como plataforma backend para el manejo de usuarios y del catálogo de libros.
+
+## Tabla de préstamos
+
+La aplicación utiliza una tabla `prestamos` para registrar cada vez que un libro es prestado. Su estructura principal es:
+
+```
+id               - identificador autoincremental
+libro_id         - referencia al libro prestado
+propietario_id   - usuario dueño del libro
+prestatario_id   - usuario que recibe el préstamo
+fecha_prestamo   - fecha en que se aceptó la solicitud
+fecha_limite_devolucion - fecha pactada para devolverlo
+fecha_devolucion - fecha real de devolución
+estado           - "activo" o "devuelto"
+```
+
+Antes esta información se guardaba parcialmente en la tabla `libros` mediante los campos `esta_con_usuario_id` y `fecha_limite_devolucion`. Ahora dichos campos se han eliminado de `libros` y sólo se usa la tabla `prestamos`.
 
 ## Ejecución local
 

--- a/js/admin_ops.js
+++ b/js/admin_ops.js
@@ -82,6 +82,33 @@ async function eliminarSolicitudAdmin(id) {
     if (error) console.error('DEBUG: admin_ops.js - Error eliminar solicitud:', error);
 }
 
+async function listarPrestamosAdmin() {
+    if (!supabaseClientInstance) return [];
+    const { data, error } = await supabaseClientInstance.from('prestamos').select('*').order('id', { ascending: true });
+    if (error) { console.error('DEBUG: admin_ops.js - Error listar prestamos:', error); return []; }
+    return data || [];
+}
+
+async function crearPrestamoAdmin(prestamo) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('prestamos').insert(prestamo).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error crear prestamo:', error); return null; }
+    return data;
+}
+
+async function editarPrestamoAdmin(id, campos) {
+    if (!supabaseClientInstance) return null;
+    const { data, error } = await supabaseClientInstance.from('prestamos').update(campos).eq('id', id).select().single();
+    if (error) { console.error('DEBUG: admin_ops.js - Error editar prestamo:', error); return null; }
+    return data;
+}
+
+async function eliminarPrestamoAdmin(id) {
+    if (!supabaseClientInstance) return;
+    const { error } = await supabaseClientInstance.from('prestamos').delete().eq('id', id);
+    if (error) console.error('DEBUG: admin_ops.js - Error eliminar prestamo:', error);
+}
+
 async function listarNotificacionesAdmin() {
     if (!supabaseClientInstance) return [];
     const { data, error } = await supabaseClientInstance.from('notificaciones').select('*').order('id', { ascending: true });
@@ -123,6 +150,11 @@ window.listarSolicitudesAdmin = listarSolicitudesAdmin;
 window.crearSolicitudAdmin = crearSolicitudAdmin;
 window.editarSolicitudAdmin = editarSolicitudAdmin;
 window.eliminarSolicitudAdmin = eliminarSolicitudAdmin;
+
+window.listarPrestamosAdmin = listarPrestamosAdmin;
+window.crearPrestamoAdmin = crearPrestamoAdmin;
+window.editarPrestamoAdmin = editarPrestamoAdmin;
+window.eliminarPrestamoAdmin = eliminarPrestamoAdmin;
 
 window.listarNotificacionesAdmin = listarNotificacionesAdmin;
 window.crearNotificacionAdmin = crearNotificacionAdmin;

--- a/test_app_test.js
+++ b/test_app_test.js
@@ -90,5 +90,33 @@ window.addEventListener('load', () => {
     }
 });
 
-// La llave extra al final de tu app_test.js también estaba aquí, la he eliminado.
-console.log("app_test.js: Script finalizado (asignación de listeners).");
+async function testPrestamoCrud() {
+    if (!supabaseClientInstance) {
+        updateStatus('Supabase no inicializado para pruebas', 'error');
+        return;
+    }
+    try {
+        const { data: prestamo, error } = await supabaseClientInstance
+            .from('prestamos')
+            .insert({
+                libro_id: -1,
+                propietario_id: -1,
+                prestatario_id: -1,
+                fecha_prestamo: new Date().toISOString(),
+                estado: 'activo'
+            })
+            .select()
+            .single();
+        if (error) throw error;
+        await supabaseClientInstance
+            .from('prestamos')
+            .update({ fecha_devolucion: new Date().toISOString(), estado: 'devuelto' })
+            .eq('id', prestamo.id);
+        updateStatus('Prueba de prestamos ejecutada', 'success');
+    } catch (err) {
+        console.error('Prueba de prestamos falló', err);
+        updateStatus('Error prueba prestamos: ' + err.message, 'error');
+    }
+}
+
+console.log("app_test.js: Script finalizado (asignación de listeners).\n");


### PR DESCRIPTION
## Summary
- add documentation for new `prestamos` table
- record accepted requests in `prestamos` and update book status
- update return flow to mark loan rows as returned
- fetch loans using joins to the new table
- adjust admin helpers for loan management
- extend test script with basic loan check

## Testing
- `node -c js/libros_ops.js`
- `node -c js/libros_ui.js`
- `node -c js/ui_render_views.js`
- `node -c js/admin_ops.js`
- `node -c test_app_test.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c206fa470832987cef82d732bb5dc