### PR TITLE
Fix listing and remove old fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ estado           - "activo" o "devuelto"
 ```
 
 Antes esta información se guardaba parcialmente en la tabla `libros` mediante los campos `esta_con_usuario_id` y `fecha_limite_devolucion`. Ahora dichos campos se han eliminado de `libros` y sólo se usa la tabla `prestamos`.
+El campo `propietario_avatar` también dejó de existir porque el avatar se lee directamente desde la tabla `usuarios`.
 
 ## Ejecución local
 

--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -178,7 +178,7 @@ async function handleAnadirLibroSubmit(event) {
         if (errorSubida) { throw errorSubida; }
         const { data: dataUrlPublica } = supabaseClientInstance.storage.from('portadas-libros').getPublicUrl(nombreArchivoFoto);
         const urlFotoPublica = dataUrlPublica.publicUrl; console.log("DEBUG: libros_ops.js - Foto subida, URL pública:", urlFotoPublica);
-        const { error: errorLibro } = await supabaseClientInstance.from('libros').insert([{ titulo: titulo, foto_url: urlFotoPublica, google_link: `https://www.google.com/search?q=${encodeURIComponent(titulo)}`, propietario_id: currentUser.id, propietario_avatar: currentUser.nombre_avatar, estado: 'disponible' }]).select();
+        const { error: errorLibro } = await supabaseClientInstance.from('libros').insert([{ titulo: titulo, foto_url: urlFotoPublica, google_link: `https://www.google.com/search?q=${encodeURIComponent(titulo)}`, propietario_id: currentUser.id, estado: 'disponible' }]).select();
         if (errorLibro) { throw errorLibro; }
         console.log("Libro añadido exitosamente."); document.getElementById('form-anadir-libro').reset();
         const previewFoto = document.getElementById('libro-foto-preview'); if(previewFoto) { previewFoto.src = '#'; previewFoto.style.display = 'none'; }

--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -22,7 +22,7 @@ async function cargarYMostrarLibros(append = false) {
                     propietario:usuarios!propietario_id ( nickname ),
                     prestamo:prestamos!libro_id ( prestatario_id, fecha_limite_devolucion, estado, prestatario:usuarios!prestatario_id ( nickname ) )
                 `)
-                .eq('prestamo.estado', 'activo')
+                .or('prestamo.estado.eq.activo,prestamo.estado.is.null')
                 .order('created_at', { ascending: false });
             if (error) { throw error; }
             librosFiltrados = libros || [];


### PR DESCRIPTION
## Summary
- query books also without loans
- remove old `propietario_avatar` field on insert
- document avatar field removal

## Testing
- `npm test` *(fails: package.json missing)*
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684c2cb5eb848329929dca227583df9a