### PR TITLE
Fix book query filter in libros_ui.js

### DIFF
--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -22,7 +22,7 @@ async function cargarYMostrarLibros(append = false) {
                     propietario:usuarios!propietario_id ( nickname ),
                     prestamo:prestamos!libro_id ( prestatario_id, fecha_limite_devolucion, estado, prestatario:usuarios!prestatario_id ( nickname ) )
                 `)
-                .or('prestamo.estado.eq.activo,prestamo.estado.is.null')
+                .filter('prestamo.estado', 'in', '("activo",null)')
                 .order('created_at', { ascending: false });
             if (error) { throw error; }
             librosFiltrados = libros || [];


### PR DESCRIPTION
## Summary
- avoid 400 error on book listing
- use `filter` instead of a failing `or` clause

## Testing
- `node --check js/libros_ui.js`

------
https://chatgpt.com/codex/tasks/task_e_684c592743e883298a2084f14b483a0f