### PR TITLE
Update notification refresh after loan response

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -135,6 +135,7 @@ async function responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, p
                 if (currentUser.id === propietarioId) currentUser.reputacion = nRP;
             }
             agregarNotificacion(solicitanteId, `Tu solicitud para "${libroTitulo}" fue aceptada`);
+            await refrescarNotificaciones();
         } else if (nuevoEstado === 'rechazada' && libroId) {
             const { data: pendientes } = await supabaseClientInstance
                 .from('solicitudes_prestamo')
@@ -148,6 +149,7 @@ async function responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, p
                     .eq('propietario_id', propietarioId);
             }
             agregarNotificacion(solicitanteId, `Tu solicitud para "${libroTitulo}" fue rechazada`);
+            await refrescarNotificaciones();
         }
         console.log(`DEBUG: libros_ops.js - Solicitud ${solicitudId} actualizada a ${nuevoEstado}.`);
     } catch (err) {


### PR DESCRIPTION
## Summary
- refresh notification list immediately after sending a notification when responding to a loan request

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c6448533c8329a28adff44ecbf4e0