### PR TITLE
Corrige color del texto en mensaje de notificaciones vacías

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -393,7 +393,10 @@ function renderizarListaNotificaciones(divId, notas) {
     const div = document.getElementById(divId);
     if (!div) { console.error(`DEBUG: ui_render_views.js - Div ${divId} no encontrado para notificaciones.`); return; }
     div.innerHTML = '';
-    if (!notas || notas.length === 0) { div.innerHTML = '<p>No tienes notificaciones.</p>'; return; }
+    if (!notas || notas.length === 0) {
+        div.innerHTML = '<div class="item-notificacion">No hay mensajes nuevos.</div>';
+        return;
+    }
     for (const n of notas) {
         const item = document.createElement('div');
         item.className = n.leida ? 'item-notificacion' : 'item-notificacion nueva';


### PR DESCRIPTION
## Summary
- ensure empty-notification text uses `.item-notificacion` styling so it's visible

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d928be6848329970839dff35e4b81