### PR TITLE
Filter ranking to show only students

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -611,6 +611,7 @@ async function renderizarVistaRanking() {
         const { data, error } = await supabaseClientInstance
             .from('usuarios')
             .select('nickname, reputacion')
+            .eq('rol', 'alumno')
             .order('reputacion', { ascending: false })
             .limit(20);
         if (error) throw error;


### PR DESCRIPTION
## Summary
- restrict ranking view to accounts with role `alumno`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d981f80608329b711f179979fa1b6