### PR TITLE
Add digital book upload and viewer

### DIFF
--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -16,6 +16,7 @@ async function cargarYMostrarLibros(append = false) {
                     id,
                     titulo,
                     foto_url,
+                    archivo_url,
                     estado,
                     propietario_id,
                     created_at,
@@ -76,7 +77,13 @@ async function cargarYMostrarLibros(append = false) {
                 titulo.textContent = libro.titulo;
                 card.appendChild(titulo);
 
-                if (currentUser && currentUser.id !== libro.propietario_id && (libro.estado === 'disponible' || libro.estado === 'solicitado')) {
+                if (libro.archivo_url) {
+                    const btn = document.createElement('button');
+                    btn.className = 'btn-leer-libro boton-accion-base info';
+                    btn.textContent = 'Leer/Descargar';
+                    btn.addEventListener('click', (ev) => { ev.stopPropagation(); window.open(libro.archivo_url, '_blank'); });
+                    card.appendChild(btn);
+                } else if (currentUser && currentUser.id !== libro.propietario_id && !libro.archivo_url && (libro.estado === 'disponible' || libro.estado === 'solicitado')) {
                     const btn = document.createElement('button');
                     btn.className = 'btn-pedir-prestamo boton-accion-base pedir';
                     btn.textContent = 'Pedir';

--- a/sql/add_archivo_url.sql
+++ b/sql/add_archivo_url.sql
@@ -1,0 +1,4 @@
+-- sql/add_archivo_url.sql
+-- Adds column archivo_url to libros table for digital books
+alter table if exists public.libros
+    add column if not exists archivo_url text;


### PR DESCRIPTION
## Summary
- add `archivo_url` column via migration
- include digital file input when adding books
- handle uploading digital files to new storage bucket
- show digital download/view buttons
- prevent loan actions for digital-only books

## Testing
- `node --check js/libros_ui.js`
- `node --check js/libros_ops.js`
- `node --check js/ui_render_views.js`

------
https://chatgpt.com/codex/tasks/task_e_684dee8346e48329ad20887cbe479d12