### PR TITLE
Add book type selection flow

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -231,8 +231,9 @@ async function handleAnadirLibroSubmit(event) {
     // ... (Misma función handleAnadirLibroSubmit que tenías)
     event.preventDefault(); console.log("DEBUG: libros_ops.js - Guardando nuevo libro...");
     if (!supabaseClientInstance) { alert('Error: Supabase no está inicializado.'); return; }
-    const titulo = document.getElementById('libro-titulo').value; const fotoInput = document.getElementById('libro-foto'); const fotoFile = fotoInput.files[0]; const archivoInput = document.getElementById('libro-digital'); const archivoFile = archivoInput ? archivoInput.files[0] : null;
+    const titulo = document.getElementById('libro-titulo').value; const fotoInput = document.getElementById('libro-foto'); const fotoFile = fotoInput.files[0]; const archivoInput = document.getElementById('libro-digital'); const archivoFile = archivoInput ? archivoInput.files[0] : null; const tipoLibro=document.getElementById('libro-tipo')?document.getElementById('libro-tipo').value:'fisico';
     if (!titulo || !fotoFile) { alert("Por favor, completa el título y selecciona una foto."); return; }
+    if(tipoLibro==='digital' && !archivoFile){alert('Debes subir el archivo digital del libro.');return;}
     if (!currentUser || !currentUser.id) { alert("Error: No se pudo identificar al usuario."); renderizarVistaBienvenida(); return; } // Asume renderizarVistaBienvenida es global
     const submitButton = event.target.querySelector('button[type="submit"]'); submitButton.disabled = true; submitButton.textContent = 'Guardando...';
     try {

--- a/js/main.js
+++ b/js/main.js
@@ -76,6 +76,11 @@ function asignarEventListenersGlobales() {
         const btnVolverDashAdmin = document.getElementById('btn-volver-dashboard-desde-admin'); if(btnVolverDashAdmin)btnVolverDashAdmin.onclick=()=>renderizarDashboard();
         const btnVolverDetalle = document.getElementById('btn-volver-busqueda-desde-detalle');
         if(btnVolverDetalle) btnVolverDetalle.onclick = () => cambiarVista('vista-detalle-libro','vista-buscar-libros');
+        const btnElegirDigital=document.getElementById('btn-elegir-digital');
+        if(btnElegirDigital) btnElegirDigital.onclick=()=>{const t=document.getElementById('libro-tipo');if(t)t.value='digital';const g=document.getElementById('grupo-libro-digital');if(g)g.style.display='block';const lbl=g?g.querySelector('label'):null;if(lbl)lbl.textContent='Archivo digital (obligatorio):';const inp=document.getElementById('libro-digital');if(inp){inp.required=true;inp.value='';}cambiarVista('vista-elegir-tipo-libro','vista-anadir-libro');};
+        const btnElegirFisico=document.getElementById('btn-elegir-fisico');
+        if(btnElegirFisico) btnElegirFisico.onclick=()=>{const t=document.getElementById('libro-tipo');if(t)t.value='fisico';const g=document.getElementById('grupo-libro-digital');if(g)g.style.display='none';const inp=document.getElementById('libro-digital');if(inp){inp.required=false;inp.value='';}cambiarVista('vista-elegir-tipo-libro','vista-anadir-libro');};
+        const btnVolverElegir=document.getElementById('btn-volver-dashboard-desde-elegir'); if(btnVolverElegir)btnVolverElegir.onclick=()=>renderizarDashboard();
         document.getElementById('form-login-admin').addEventListener('submit', async (e)=>{
             e.preventDefault();
             const nick=document.getElementById('admin-alias').value;

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -109,7 +109,14 @@ function renderizarVistaBienvenida() {
             <button id="btn-admin-gestionar-notificaciones">Notificaciones</button>
             <button type="button" id="btn-volver-dashboard-desde-admin">Volver al Dashboard</button>
         </div>
-        <div id="vista-anadir-libro" class="vista"><h3>Añadir Nuevo Libro</h3><form id="form-anadir-libro"><label for="libro-titulo">Título del Libro:</label><input type="text" id="libro-titulo" required><br><br><label for="libro-foto">Foto de la Portada:</label><input type="file" id="libro-foto" accept="image/*" capture="environment" required><br><br><label for="libro-digital">Archivo digital (opcional):</label><input type="file" id="libro-digital" accept=".pdf,.epub"><br><br><img id="libro-foto-preview" src="#" alt="Vista previa de la portada" style="max-width: 200px; max-height: 200px; display: none; margin-bottom:15px;"><br><button type="submit">Guardar Libro</button><button type="button" id="btn-volver-dashboard-desde-anadir">Cancelar y Volver al Dashboard</button></form></div>
+        <div id="vista-elegir-tipo-libro" class="vista">
+            <h3>¿Libro digital o para prestar?</h3>
+            <button id="btn-elegir-digital" class="boton-accion-base cargar">Digital</button>
+            <button id="btn-elegir-fisico" class="boton-accion-base gestionar">Para prestar</button>
+            <br><br>
+            <button type="button" id="btn-volver-dashboard-desde-elegir">Cancelar y Volver al Dashboard</button>
+        </div>
+        <div id="vista-anadir-libro" class="vista"><h3>Añadir Nuevo Libro</h3><form id="form-anadir-libro"><input type="hidden" id="libro-tipo" value=""><label for="libro-titulo">Título del Libro:</label><input type="text" id="libro-titulo" required><br><br><label for="libro-foto">Foto de la Portada:</label><input type="file" id="libro-foto" accept="image/*" capture="environment" required><br><br><div id="grupo-libro-digital" style="display:none;"><label for="libro-digital">Archivo digital (opcional):</label><input type="file" id="libro-digital" accept=".pdf,.epub"></div><br><br><img id="libro-foto-preview" src="#" alt="Vista previa de la portada" style="max-width: 200px; max-height: 200px; display: none; margin-bottom:15px;"><br><button type="submit">Guardar Libro</button><button type="button" id="btn-volver-dashboard-desde-anadir">Cancelar y Volver al Dashboard</button></form></div>
         <div id="vista-gestionar-libro-propio" class="vista"><h3>Gestionar Mi Libro</h3><p>Aquí podrás editar o eliminar tu libro que esté disponible.</p><div id="detalles-libro-gestion"></div><button type="button" id="btn-volver-dashboard-desde-gestion">Volver al Dashboard</button></div>
     `;
     const selectAvatarRegistro = document.getElementById('alumno-avatar-registro');
@@ -361,7 +368,7 @@ function renderizarDashboard() {
     if (repDash) repDash.textContent = `Tu reputación: ${reputacionMostrar}`;
 
     const btnIrAnadirLibro = document.getElementById('btn-ir-anadir-libro');
-    if (btnIrAnadirLibro) { btnIrAnadirLibro.onclick = () => cambiarVista('vista-dashboard', 'vista-anadir-libro');}
+    if (btnIrAnadirLibro) { btnIrAnadirLibro.onclick = () => cambiarVista('vista-dashboard', 'vista-elegir-tipo-libro');}
     const btnIrAdminPanel = document.getElementById('btn-ir-admin-panel');
     if (btnIrAdminPanel) btnIrAdminPanel.onclick = renderizarPanelAdmin;
     console.log("DEBUG: ui_render_views.js - HTML de Dashboard completo inyectado.");


### PR DESCRIPTION
## Summary
- add a new view to choose between digital or physical book
- open the adapted book form after choosing
- hide digital upload for physical books and require it for digital
- route dashboard button through the selection view
- validate digital file presence when needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b6d2f088329bf4218c4fb19038d