### PR TITLE
Implement owner book management

### DIFF
--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -227,6 +227,44 @@ async function solicitarDevolucionAnticipada(libroId, prestatarioId, tituloLibro
 }
 
 
+async function actualizarLibroPropio(libroId, campos) {
+    console.log(`DEBUG: libros_ops.js - Actualizando libro ID: ${libroId}`, campos);
+    if (!supabaseClientInstance || !currentUser) return null;
+    try {
+        const { data, error } = await supabaseClientInstance
+            .from('libros')
+            .update(campos)
+            .eq('id', libroId)
+            .eq('propietario_id', currentUser.id)
+            .select()
+            .single();
+        if (error) throw error;
+        return data;
+    } catch (err) {
+        console.error('DEBUG: libros_ops.js - Error actualizar libro:', err);
+        return null;
+    }
+}
+
+async function eliminarLibroPropio(libroId) {
+    console.log(`DEBUG: libros_ops.js - Eliminando libro ID: ${libroId}`);
+    if (!supabaseClientInstance || !currentUser) return false;
+    try {
+        const { error } = await supabaseClientInstance
+            .from('libros')
+            .delete()
+            .eq('id', libroId)
+            .eq('propietario_id', currentUser.id)
+            .eq('estado', 'disponible');
+        if (error) throw error;
+        return true;
+    } catch (err) {
+        console.error('DEBUG: libros_ops.js - Error eliminar libro:', err);
+        return false;
+    }
+}
+
+
 async function handleAnadirLibroSubmit(event) {
     // ... (Misma función handleAnadirLibroSubmit que tenías)
     event.preventDefault(); console.log("DEBUG: libros_ops.js - Guardando nuevo libro...");
@@ -279,4 +317,8 @@ async function recargarSeccionesPrestamosDashboard() {
         asignarEventListenersLibros();
     }
 }
+
+// Exponer helpers a nivel global
+window.actualizarLibroPropio = actualizarLibroPropio;
+window.eliminarLibroPropio = eliminarLibroPropio;
 

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -323,8 +323,27 @@ async function renderizarDetallesGestionLibro(libroId) {
             detallesDiv.appendChild(infoDiv);
             detallesDiv.appendChild(accionesDiv);
 
-            document.getElementById('btn-editar-libro-info').onclick = () => alert(`Editar Libro ID: ${libro.id} (no implementado).`);
-            document.getElementById('btn-eliminar-libro').onclick = async () => alert(`Eliminar Libro ID: ${libro.id} (no implementado).`);
+            document.getElementById('btn-editar-libro-info').onclick = async () => {
+                const nuevoTitulo = prompt('Nuevo título', libro.titulo);
+                if (nuevoTitulo !== null) {
+                    await actualizarLibroPropio(libro.id, { titulo: nuevoTitulo });
+                    cargarYMostrarLibros();
+                    recargarSeccionesPrestamosDashboard();
+                    renderizarDashboard();
+                    actualizarMenuPrincipal();
+                }
+            };
+            document.getElementById('btn-eliminar-libro').onclick = async () => {
+                if (confirm('¿Eliminar libro?')) {
+                    const ok = await eliminarLibroPropio(libro.id);
+                    if (ok) {
+                        cargarYMostrarLibros();
+                        recargarSeccionesPrestamosDashboard();
+                        renderizarDashboard();
+                        actualizarMenuPrincipal();
+                    }
+                }
+            };
 
         } else { detallesDiv.innerHTML = "<p>No se encontraron detalles o no tienes permiso.</p>"; }
     } catch (error) { console.error("DEBUG: ui_render_views.js - Error cargando detalles para gestionar:", error); detallesDiv.innerHTML = `<p style="color:red;">Error: ${error.message}</p>`; }


### PR DESCRIPTION
## Summary
- add helpers to update or delete a user's own book
- export new helpers via `window`
- use the helpers from the manage-book view with prompts and refreshes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685038087274832990ded8ab7e7b9475