### PR TITLE
Add inline book edit form

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -323,7 +323,35 @@ async function renderizarDetallesGestionLibro(libroId) {
             detallesDiv.appendChild(infoDiv);
             detallesDiv.appendChild(accionesDiv);
 
-            document.getElementById('btn-editar-libro-info').onclick = () => alert(`Editar Libro ID: ${libro.id} (no implementado).`);
+            const formEdit = document.createElement('form');
+            formEdit.id = 'form-editar-libro';
+            formEdit.style.display = 'none';
+            formEdit.innerHTML = `
+                <label for="editar-titulo">Título:</label>
+                <input type="text" id="editar-titulo" value="${libro.titulo}" required><br><br>
+                <label for="editar-foto">Nueva portada (opcional):</label>
+                <input type="file" id="editar-foto" accept="image/*"><br><br>
+                <label for="editar-archivo">Nuevo archivo (opcional):</label>
+                <input type="file" id="editar-archivo" accept=".pdf,.epub"><br><br>
+                <button type="submit" class="boton-accion-base submit">Guardar Cambios</button>
+                <button type="button" id="cancelar-edicion-libro" class="boton-accion-base gestionar">Cancelar</button>
+            `;
+            detallesDiv.appendChild(formEdit);
+
+            document.getElementById('btn-editar-libro-info').onclick = () => {
+                formEdit.style.display = 'block';
+            };
+            document.getElementById('cancelar-edicion-libro').onclick = () => {
+                formEdit.style.display = 'none';
+            };
+            formEdit.addEventListener('submit', async (e) => {
+                e.preventDefault();
+                const nuevoTitulo = document.getElementById('editar-titulo').value.trim();
+                const fotoFile = document.getElementById('editar-foto').files[0];
+                const archivoFile = document.getElementById('editar-archivo').files[0];
+                await editarLibroPropio(libro.id, { titulo: nuevoTitulo, fotoFile, archivoFile });
+                renderizarDetallesGestionLibro(libro.id);
+            });
             document.getElementById('btn-eliminar-libro').onclick = async () => alert(`Eliminar Libro ID: ${libro.id} (no implementado).`);
 
         } else { detallesDiv.innerHTML = "<p>No se encontraron detalles o no tienes permiso.</p>"; }


### PR DESCRIPTION
## Summary
- allow book owners to edit their book
- add edit form inside book management view
- implement `editarLibroPropio` to update title, cover and file

## Testing
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6850380f22d4832985be6af564ececaf