### PR TITLE
Add popup message overlay with notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
         </div>
         <div id="popup-notificaciones" class="popup-notificaciones"></div>
     </header>
+    <div id="popup-mensaje" class="popup-mensaje"></div>
 
     <main id="contenedor-principal">
         <p id="parrafo-carga-inicial" style="text-align: center; padding: 20px;">Cargando LibroVa...</p>

--- a/js/libros_ops.js
+++ b/js/libros_ops.js
@@ -164,6 +164,7 @@ async function responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, p
             }
             agregarNotificacion(solicitanteId, `Tu solicitud para "${libroTitulo}" fue aceptada`);
             await refrescarNotificaciones();
+            mostrarPopupMensaje(`Recuerda llevarle \"${libroTitulo}\" a ${solicitanteNickname} mañana al aula.`);
         } else if (nuevoEstado === 'rechazada' && libroId) {
             const { data: pendientes } = await supabaseClientInstance
                 .from('solicitudes_prestamo')
@@ -178,6 +179,7 @@ async function responderSolicitudPrestamo(solicitudId, libroId, solicitanteId, p
             }
             agregarNotificacion(solicitanteId, `Tu solicitud para "${libroTitulo}" fue rechazada`);
             await refrescarNotificaciones();
+            mostrarPopupMensaje(`Has rechazado la solicitud para \"${libroTitulo}\".`);
         }
         console.log(`DEBUG: libros_ops.js - Solicitud ${solicitudId} actualizada a ${nuevoEstado}.`);
     } catch (err) {

--- a/js/notificaciones.js
+++ b/js/notificaciones.js
@@ -62,9 +62,13 @@ window.eliminarNotificacion = eliminarNotificacion;
 
 async function refrescarNotificaciones() {
     if (!currentUser) return;
+    const idsPrevios = notificaciones.map(n => n.id);
     notificaciones = await cargarNotificacionesUsuario(currentUser.id);
-    notificacionesNuevas = notificaciones.filter(n => !n.leida).length;
+    const noLeidas = notificaciones.filter(n => !n.leida);
+    notificacionesNuevas = noLeidas.length;
+    const nuevasEntradas = noLeidas.filter(n => !idsPrevios.includes(n.id));
     actualizarMenuPrincipal();
+    nuevasEntradas.forEach(nueva => mostrarPopupMensaje(nueva.mensaje));
 }
 
 window.refrescarNotificaciones = refrescarNotificaciones;

--- a/js/ui_navigation.js
+++ b/js/ui_navigation.js
@@ -129,3 +129,22 @@ function actualizarMenuPrincipal() {
     }
 }
 
+function mostrarPopupMensaje(texto) {
+    const popup = document.getElementById('popup-mensaje');
+    if (!popup) return;
+    popup.innerHTML = `<div class="contenido"><p>${texto}</p><button id="btn-cerrar-popup-mensaje">Cerrar</button></div>`;
+    popup.style.display = 'flex';
+    const btnCerrar = document.getElementById('btn-cerrar-popup-mensaje');
+    if (btnCerrar) btnCerrar.onclick = ocultarPopupMensaje;
+}
+
+function ocultarPopupMensaje() {
+    const popup = document.getElementById('popup-mensaje');
+    if (!popup) return;
+    popup.style.display = 'none';
+    popup.innerHTML = '';
+}
+
+window.mostrarPopupMensaje = mostrarPopupMensaje;
+window.ocultarPopupMensaje = ocultarPopupMensaje;
+

--- a/style.css
+++ b/style.css
@@ -445,3 +445,29 @@ form button[type="button"]:hover {
 }
 #popup-notificaciones .item-notificacion { margin-bottom: 8px; }
 #popup-notificaciones .item-notificacion:last-child { margin-bottom: 0; }
+
+#popup-mensaje {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: none;
+    background-color: rgba(0,0,0,0.6);
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+#popup-mensaje .contenido {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+    max-width: 320px;
+    text-align: center;
+    position: relative;
+}
+#popup-mensaje .contenido button {
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- create `#popup-mensaje` container on the page
- style popup overlay and its inner content
- add global helpers `mostrarPopupMensaje` and `ocultarPopupMensaje`
- show popup messages when responding to loan requests
- detect new notifications and display popup with the message

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68503b7c04f883298c6258c6d82495b8