### PR TITLE
Remove ranking query limit

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -675,8 +675,7 @@ async function renderizarVistaRanking() {
             .from('usuarios')
             .select('nickname, reputacion')
             .eq('rol', 'alumno')
-            .order('reputacion', { ascending: false })
-            .limit(20);
+            .order('reputacion', { ascending: false });
         if (error) throw error;
         if (!data || data.length === 0) { rankingDiv.innerHTML = '<p>No hay usuarios.</p>'; return; }
         rankingDiv.innerHTML = '<ol class="lista-ranking"></ol>';


### PR DESCRIPTION
## Summary
- fetch all users in the ranking view by removing the `limit(20)` call

## Testing
- `node --version` *(fails: Node not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68504186cf8083299f8ceb94319d6e0c