### PR TITLE
Show intro on user registration

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -4,9 +4,17 @@ console.log("DEBUG: config.js - Cargado.");
 const X_SUPABASE_URL = 'https://srqdgsgxkxfiveynxkwt.supabase.co'; 
 const X_SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNycWRnc2d4a3hmaXZleW54a3d0Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg1Mjg2MjUsImV4cCI6MjA2NDEwNDYyNX0.xenXPUm17l0LvbvUk0fsbVik3y5uKP3ADwaVN5BcKGY';
 
-const AVATARES_DISPONIBLES = [ 
+const AVATARES_DISPONIBLES = [
     { id: 'avatar_robot', nombre: 'Robot', emoji: '🤖' }, { id: 'avatar_pelota', nombre: 'Pelota', emoji: '⚽️' },
     { id: 'avatar_perro', nombre: 'Perro', emoji: '🐶' }, { id: 'avatar_gato', nombre: 'Gato', emoji: '🐱' },
     { id: 'avatar_cohete', nombre: 'Cohete', emoji: '🚀' }, { id: 'avatar_mago', nombre: 'Mago', emoji: '🧙' },
     { id: 'avatar_unicornio', nombre: 'Unicornio', emoji: '🦄' }, { id: 'avatar_panda', nombre: 'Panda', emoji: '🐼' }
 ];
+
+// Texto introductorio que se muestra antes de crear un usuario
+const MENSAJE_INTRO_REGISTRO = `¡Hola! LibroVa es una app para que compartas libros con tus compañeros.<br>
+Puedes prestar tus propios libros y pedir prestados los de los demás.<br>
+Cada vez que devuelves un libro a tiempo tu reputación mejora y subes en el ranking.<br>
+También puedes subir libros digitales para que otros los lean.<br>
+Para entrar elige un avatar, un apodo y un PIN de 4 números.<br>
+Si estás de acuerdo, presiona “Aceptar” y empieza a disfrutar de la lectura.`;

--- a/js/main.js
+++ b/js/main.js
@@ -62,7 +62,12 @@ function asignarEventListenersGlobales() {
         if(btnMostrarLoginAvatar) { btnMostrarLoginAvatar.onclick = () => { if(document.getElementById('seleccion-login-registro-alumno')) document.getElementById('seleccion-login-registro-alumno').style.display = 'none'; if(document.getElementById('contenedor-login-avatar')) document.getElementById('contenedor-login-avatar').style.display = 'block'; if(document.getElementById('selector-avatares-login')) document.getElementById('selector-avatares-login').style.display = 'flex'; if(document.getElementById('form-login-alumno-pin')) document.getElementById('form-login-alumno-pin').style.display = 'none'; };
         } else { console.error("DEBUG: main.js - Botón 'btn-mostrar-form-login-avatar' NO ENCONTRADO."); }
         const btnMostrarFormRegistro = document.getElementById('btn-mostrar-form-registro-alumno');
-        if(btnMostrarFormRegistro) { btnMostrarFormRegistro.onclick = () => cambiarVista('vista-login-alumno', 'vista-registro-alumno');
+        if(btnMostrarFormRegistro) {
+            btnMostrarFormRegistro.onclick = () => {
+                mostrarPopupAceptacion(MENSAJE_INTRO_REGISTRO, () => {
+                    cambiarVista('vista-login-alumno', 'vista-registro-alumno');
+                });
+            };
         } else { console.error("DEBUG: main.js - Botón 'btn-mostrar-form-registro-alumno' NO ENCONTRADO."); }
         const btnVolverBienvenidaAlumno = document.getElementById('btn-volver-bienvenida-alumno');
         if (btnVolverBienvenidaAlumno) { btnVolverBienvenidaAlumno.onclick = () => { const sel = document.getElementById('seleccion-login-registro-alumno'); const cla = document.getElementById('contenedor-login-avatar'); if(sel) sel.style.display = 'block'; if(cla) cla.style.display = 'none'; cambiarVista('vista-login-alumno', 'vista-bienvenida'); };

--- a/js/ui_navigation.js
+++ b/js/ui_navigation.js
@@ -138,6 +138,18 @@ function mostrarPopupMensaje(texto) {
     if (btnCerrar) btnCerrar.onclick = ocultarPopupMensaje;
 }
 
+function mostrarPopupAceptacion(texto, onAceptar) {
+    const popup = document.getElementById('popup-mensaje');
+    if (!popup) return;
+    popup.innerHTML = `<div class="contenido"><p>${texto}</p><button id="btn-aceptar-popup-mensaje">Aceptar</button></div>`;
+    popup.style.display = 'flex';
+    const btnAceptar = document.getElementById('btn-aceptar-popup-mensaje');
+    if (btnAceptar) btnAceptar.onclick = () => {
+        ocultarPopupMensaje();
+        if (typeof onAceptar === 'function') onAceptar();
+    };
+}
+
 function ocultarPopupMensaje() {
     const popup = document.getElementById('popup-mensaje');
     if (!popup) return;
@@ -147,4 +159,5 @@ function ocultarPopupMensaje() {
 
 window.mostrarPopupMensaje = mostrarPopupMensaje;
 window.ocultarPopupMensaje = ocultarPopupMensaje;
+window.mostrarPopupAceptacion = mostrarPopupAceptacion;
 


### PR DESCRIPTION
## Summary
- store an intro message in `config.js`
- add `mostrarPopupAceptacion` helper for confirmation popups
- show the intro popup before displaying the registration form

## Testing
- `node --check js/ui_navigation.js`
- `node --check js/main.js`
- `node --check js/config.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685083c6f1208329bb5ac39190d0b626