### PR TITLE
Integrate PDF.js viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Los valores `X_SUPABASE_URL` y `X_SUPABASE_ANON_KEY` se cargan desde variables d
 
 Para verificar que la conexión con Supabase está correctamente configurada puedes abrir [`test_index.html`](test_index.html). Este archivo carga `test_app_test.js` y muestra mensajes básicos de éxito o error.
 
+## Librerías adicionales
+
+La visualización de PDFs se realiza con [PDF.js](https://mozilla.github.io/pdf.js/), distribuida bajo la [licencia Apache 2.0](https://github.com/mozilla/pdf.js/blob/master/LICENSE).
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/index.html
+++ b/index.html
@@ -41,6 +41,14 @@
     <script src="js/libros_ui.js"></script>
     <script src="js/admin_ops.js"></script>
     <script src="js/notificaciones.js"></script>
+    <!-- PDF.js desde CDN oficial -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.min.js"></script>
+    <script>
+        if (window.pdfjsLib) {
+            window.pdfjsLib.GlobalWorkerOptions.workerSrc =
+                'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.8.162/pdf.worker.min.js';
+        }
+    </script>
     <script src="js/ui_render_views.js"></script>
     <script src="js/main.js"></script>
 

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -506,12 +506,29 @@ async function renderizarVistaDetalleLibro(libroId) {
             btnLeer.onclick = () => window.open(libro.archivo_url, '_blank');
             cont.appendChild(btnLeer);
             if (libro.archivo_url.toLowerCase().endsWith('.pdf')) {
-                const iframe = document.createElement('iframe');
-                iframe.src = libro.archivo_url;
-                iframe.style.width = '100%';
-                iframe.style.height = '500px';
-                iframe.style.marginTop = '10px';
-                cont.appendChild(iframe);
+                const pdfDiv = document.createElement('div');
+                pdfDiv.className = 'pdf-viewer';
+                cont.appendChild(pdfDiv);
+                if (window.pdfjsLib && pdfjsLib.getDocument) {
+                    const loadingTask = pdfjsLib.getDocument(libro.archivo_url);
+                    loadingTask.promise.then(pdf => pdf.getPage(1)).then(page => {
+                        const viewport = page.getViewport({ scale: 1.2 });
+                        const canvas = document.createElement('canvas');
+                        canvas.width = viewport.width;
+                        canvas.height = viewport.height;
+                        pdfDiv.appendChild(canvas);
+                        const ctx = canvas.getContext('2d');
+                        page.render({ canvasContext: ctx, viewport }).promise.catch(err => {
+                            pdfDiv.innerHTML = '<p class="error-pdf">Error al renderizar PDF.</p>';
+                            console.error('PDF render error', err);
+                        });
+                    }).catch(err => {
+                        pdfDiv.innerHTML = '<p class="error-pdf">No se pudo cargar el PDF.</p>';
+                        console.error('PDF loading error', err);
+                    });
+                } else {
+                    pdfDiv.innerHTML = '<p class="error-pdf">Visualizador de PDF no disponible.</p>';
+                }
             }
         }
         let prestamoDetalle = null;

--- a/style.css
+++ b/style.css
@@ -471,3 +471,21 @@ form button[type="button"]:hover {
 #popup-mensaje .contenido button {
     margin-top: 10px;
 }
+
+/* Visualizador PDF */
+.pdf-viewer {
+    width: 100%;
+    max-height: 500px;
+    overflow: auto;
+    margin-top: 10px;
+    border: 1px solid #CBD5E0;
+}
+.pdf-viewer canvas {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+.error-pdf {
+    color: red;
+    padding: 10px;
+}


### PR DESCRIPTION
## Summary
- load PDF.js from CDN and set worker source
- view PDF files using PDF.js instead of an iframe
- style the PDF viewer container
- mention PDF.js license in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516101b2b88329b8ba526007367282