### PR TITLE
Add inline EPUB reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ python3 -m http.server
 
 Luego visita `http://localhost:8000/index.html`.
 
+## Lectura de libros digitales
+
+Los archivos EPUB se muestran directamente en la página gracias a [epub.js](https://github.com/futurepress/epub.js). Si un libro digital es EPUB, al hacer clic en **Leer/Descargar** se abrirá un visor integrado para leer sin salir del sitio. Para otros formatos se abre una nueva pestaña.
+
 ## Video de fondo
 
 La página principal muestra el video `fondo.mp4` como fondo animado. Puedes

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
     <script src="js/libros_ui.js"></script>
     <script src="js/admin_ops.js"></script>
     <script src="js/notificaciones.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/epubjs/dist/epub.min.js"></script>
     <script src="js/ui_render_views.js"></script>
     <script src="js/main.js"></script>
 

--- a/js/libros_ui.js
+++ b/js/libros_ui.js
@@ -81,7 +81,14 @@ async function cargarYMostrarLibros(append = false) {
                     const btn = document.createElement('button');
                     btn.className = 'btn-leer-libro boton-accion-base info';
                     btn.textContent = 'Leer/Descargar';
-                    btn.addEventListener('click', (ev) => { ev.stopPropagation(); window.open(libro.archivo_url, '_blank'); });
+                    btn.addEventListener('click', (ev) => {
+                        ev.stopPropagation();
+                        if (libro.archivo_url.toLowerCase().endsWith('.epub')) {
+                            renderizarVistaDetalleLibro(libro.id);
+                        } else {
+                            window.open(libro.archivo_url, '_blank');
+                        }
+                    });
                     card.appendChild(btn);
                 } else if (currentUser && currentUser.id !== libro.propietario_id && !libro.archivo_url && (libro.estado === 'disponible' || libro.estado === 'solicitado')) {
                     const btn = document.createElement('button');

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -512,6 +512,18 @@ async function renderizarVistaDetalleLibro(libroId) {
                 iframe.style.height = '500px';
                 iframe.style.marginTop = '10px';
                 cont.appendChild(iframe);
+            } else if (libro.archivo_url.toLowerCase().endsWith('.epub')) {
+                const epubDiv = document.createElement('div');
+                epubDiv.id = 'epub-viewer';
+                cont.appendChild(epubDiv);
+                if (window.ePub) {
+                    const book = ePub(libro.archivo_url);
+                    const rendition = book.renderTo('epub-viewer', {
+                        width: '100%',
+                        height: '500px'
+                    });
+                    rendition.display();
+                }
             }
         }
         let prestamoDetalle = null;

--- a/style.css
+++ b/style.css
@@ -471,3 +471,9 @@ form button[type="button"]:hover {
 #popup-mensaje .contenido button {
     margin-top: 10px;
 }
+
+#epub-viewer {
+    width: 100%;
+    height: 500px;
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- load epub.js via CDN
- support viewing `.epub` files inline using the viewer
- style the viewer to match the PDF frame
- trigger inline viewer when clicking **Leer/Descargar** on an EPUB
- document EPUB support

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68516103bc3483299c815c79dade7150