### PR TITLE
Handle missing ePub viewer

### DIFF
--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -517,6 +517,7 @@ async function renderizarVistaDetalleLibro(libroId) {
                 const epubDiv = document.createElement('div');
                 epubDiv.id = 'epub-viewer';
                 cont.appendChild(epubDiv);
+
                 if (window.ePub) {
                     const book = ePub(libro.archivo_url);
                     const rendition = book.renderTo('epub-viewer', {
@@ -524,6 +525,11 @@ async function renderizarVistaDetalleLibro(libroId) {
                         height: '500px'
                     });
                     rendition.display();
+                } else {
+                    const pError = document.createElement('p');
+                    pError.textContent = 'Error: EPUB.js no disponible';
+                    epubDiv.appendChild(pError);
+                    console.error('DEBUG: ui_render_views.js - window.ePub no definido. No se puede renderizar EPUB.');
                 }
             }
         }


### PR DESCRIPTION
## Summary
- check for `window.ePub` before rendering epub
- show an error message and log if EPUB.js isn't available

## Testing
- `node test_app_test.js` *(fails: document is not defined)*
- `npm test` *(fails: no `package.json` found)*

------
https://chatgpt.com/codex/tasks/task_e_68517fd01e608329b3b35cab1b3c9291