### PR TITLE
Add audio deepfake detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Para verificar que la conexión con Supabase está correctamente configurada pue
 
 La visualización de PDFs se realiza con [PDF.js](https://mozilla.github.io/pdf.js/), distribuida bajo la [licencia Apache 2.0](https://github.com/mozilla/pdf.js/blob/master/LICENSE).
 
+## Detector de audios fake
+
+El panel de administración incluye un enlace a `audio_detector.html`. Esta página permite entrenar un pequeño modelo con audios reales y analizar nuevos archivos para clasificarlos como **REAL** o **FAKE**. El procesamiento se realiza en el navegador utilizando [Meyda](https://meyda.js.org/) para extraer características de audio y [Chart.js](https://www.chartjs.org/) para mostrar gráficos comparativos.
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/audio_detector.html
+++ b/audio_detector.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Detector de Audios Fake</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+</head>
+<body class="grey lighten-4">
+    <nav>
+        <div class="nav-wrapper blue">
+            <a href="#" class="brand-logo center">Detector de Audios Fake</a>
+            <ul id="nav-mobile" class="left">
+                <li><a href="index.html">Volver</a></li>
+            </ul>
+        </div>
+    </nav>
+
+    <div class="container" style="margin-top:30px;">
+        <div class="card">
+            <div class="card-content">
+                <span class="card-title">Entrenamiento</span>
+                <div class="file-field input-field">
+                    <div class="btn">
+                        <span>Audios verdaderos</span>
+                        <input type="file" id="train-audios" accept="audio/*" multiple>
+                    </div>
+                    <div class="file-path-wrapper">
+                        <input class="file-path validate" type="text" placeholder="Sube varios audios reales">
+                    </div>
+                </div>
+                <button class="btn" id="btn-train">Entrenar</button>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-content">
+                <span class="card-title">Análisis</span>
+                <div class="file-field input-field">
+                    <div class="btn">
+                        <span>Audio a verificar</span>
+                        <input type="file" id="test-audio" accept="audio/*">
+                    </div>
+                    <div class="file-path-wrapper">
+                        <input class="file-path validate" type="text">
+                    </div>
+                </div>
+                <button class="btn" id="btn-analyze">Analizar</button>
+                <div id="result" class="section"></div>
+            </div>
+        </div>
+
+        <canvas id="chart" style="max-width:100%;"></canvas>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="https://unpkg.com/meyda/dist/web/meyda.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="js/audio_detector.js"></script>
+</body>
+</html>

--- a/js/audio_detector.js
+++ b/js/audio_detector.js
@@ -1,0 +1,106 @@
+let audioCtx;
+let trainingProfile = null;
+
+function initAudio() {
+    if (!audioCtx) {
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    }
+}
+
+function fileToArrayBuffer(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsArrayBuffer(file);
+    });
+}
+
+async function extractFeatures(arrayBuffer) {
+    initAudio();
+    const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+    const channelData = audioBuffer.getChannelData(0);
+    const bufferSize = 512;
+    const hop = 256;
+    let centroidSum = 0;
+    let rmsSum = 0;
+    let count = 0;
+    for (let i = 0; i + bufferSize <= channelData.length; i += hop) {
+        const slice = channelData.slice(i, i + bufferSize);
+        const features = Meyda.extract(['rms', 'spectralCentroid'], slice);
+        centroidSum += features.spectralCentroid || 0;
+        rmsSum += features.rms || 0;
+        count++;
+    }
+    if (count === 0) return { centroid: 0, rms: 0 };
+    return { centroid: centroidSum / count, rms: rmsSum / count };
+}
+
+async function train() {
+    const files = document.getElementById('train-audios').files;
+    if (!files.length) {
+        M.toast({ html: 'Selecciona audios para entrenar' });
+        return;
+    }
+    let centroidTotal = 0;
+    let rmsTotal = 0;
+    for (const file of files) {
+        const buf = await fileToArrayBuffer(file);
+        const f = await extractFeatures(buf);
+        centroidTotal += f.centroid;
+        rmsTotal += f.rms;
+    }
+    trainingProfile = {
+        centroid: centroidTotal / files.length,
+        rms: rmsTotal / files.length
+    };
+    M.toast({ html: 'Entrenamiento completado' });
+}
+
+function probabilityFromDistance(d) {
+    const normalized = Math.min(d / (trainingProfile.centroid + 0.0001), 1);
+    return Math.max(0, 100 - normalized * 100);
+}
+
+function drawChart(train, test) {
+    const ctx = document.getElementById('chart');
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: ['Centroid', 'RMS'],
+            datasets: [
+                { label: 'Entrenamiento', data: [train.centroid, train.rms], backgroundColor: 'rgba(33,150,243,0.5)' },
+                { label: 'Prueba', data: [test.centroid, test.rms], backgroundColor: 'rgba(244,67,54,0.5)' }
+            ]
+        },
+        options: { responsive: true, scales: { y: { beginAtZero: true } } }
+    });
+}
+
+async function analyze() {
+    if (!trainingProfile) {
+        M.toast({ html: 'Primero entrena con audios reales' });
+        return;
+    }
+    const file = document.getElementById('test-audio').files[0];
+    if (!file) {
+        M.toast({ html: 'Selecciona un audio a analizar' });
+        return;
+    }
+    const buf = await fileToArrayBuffer(file);
+    const f = await extractFeatures(buf);
+    const dist = Math.sqrt(
+        Math.pow(f.centroid - trainingProfile.centroid, 2) +
+        Math.pow(f.rms - trainingProfile.rms, 2)
+    );
+    const prob = probabilityFromDistance(dist);
+    const clasificacion = prob > 50 ? 'REAL' : 'FAKE';
+    document.getElementById('result').innerHTML = `<h5>Resultado: ${clasificacion} (${prob.toFixed(1)}% certeza)</h5>`;
+    drawChart(trainingProfile, f);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    M.AutoInit();
+    document.getElementById('btn-train').addEventListener('click', train);
+    document.getElementById('btn-analyze').addEventListener('click', analyze);
+});

--- a/js/ui_render_views.js
+++ b/js/ui_render_views.js
@@ -750,6 +750,10 @@ async function renderizarPanelAdmin() {
             <h4>Notificaciones</h4>
             <div id="admin-lista-notificaciones">Cargando...</div>
         </div>
+        <div class="seccion-dashboard">
+            <h4>Herramientas</h4>
+            <button id="btn-admin-audio-detector" class="boton-accion-base gestionar">Detector de Audios</button>
+        </div>
         <button type="button" id="btn-volver-dashboard-desde-admin" class="boton-accion-base gestionar">Volver a Inicio</button>
     `;
     cambiarVista(vistaActual ? vistaActual.id : null, 'vista-admin-panel');
@@ -789,6 +793,8 @@ async function renderizarPanelAdmin() {
     }
 
     document.getElementById('btn-volver-dashboard-desde-admin').onclick = renderizarDashboard;
+    const btnAudioDetector = document.getElementById('btn-admin-audio-detector');
+    if (btnAudioDetector) btnAudioDetector.onclick = () => { window.location.href = 'audio_detector.html'; };
 }
 
 async function cargarDatosPanelAdmin() {


### PR DESCRIPTION
## Summary
- add Material Design page `audio_detector.html` to train on real audio samples and classify new ones as REAL or FAKE
- implement detection logic and charts in `js/audio_detector.js`
- link new tool from the admin panel
- document fake audio detector in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862916359cc832982b9b1eb22cc3fec