### PR TITLE
Add simple weekly calendar

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agenda Semanal</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-components-web/14.0.0/material-components-web.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.css">
+    <style>
+        body { margin:0; font-family: Roboto, sans-serif; }
+        header { background:#6200ee; color:#fff; padding:16px; position:fixed; top:0; left:0; right:0; z-index:1000; display:flex; align-items:center; }
+        header h1 { margin:0; font-size:1.25rem; }
+        #calendar { max-width:900px; margin:80px auto; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Agenda Semanal</h1>
+    </header>
+    <div id="calendar"></div>
+
+    <script src="js/supabase.js"></script>
+    <script src="js/config.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/material-components-web/14.0.0/material-components-web.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.0/main.min.js"></script>
+    <script src="js/calendar.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,10 @@
             <img src="header.png" alt="CuidApp">
             <span>CuidApp</span>
         </a>
+        <a href="calendar.html" class="app-tile">
+            <img src="header.png" alt="Agenda">
+            <span>Agenda</span>
+        </a>
         <a href="#" class="app-tile disabled">
             <div class="placeholder"></div>
             <span>Próximamente</span>

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,0 +1,75 @@
+// js/calendar.js
+// Simple weekly calendar using FullCalendar and Supabase
+
+let supabaseCalendarClient = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  if (typeof window.supabase !== 'undefined') {
+    supabaseCalendarClient = window.supabase.createClient(X_SUPABASE_URL, X_SUPABASE_ANON_KEY);
+  }
+  const calendarEl = document.getElementById('calendar');
+  const calendar = new FullCalendar.Calendar(calendarEl, {
+    initialView: 'timeGridWeek',
+    locale: 'es',
+    selectable: true,
+    editable: true,
+    select: async (info) => {
+      const title = prompt('Título del evento:');
+      if (title && supabaseCalendarClient) {
+        const { data, error } = await supabaseCalendarClient
+          .from('eventos')
+          .insert({ titulo: title, inicio: info.startStr, fin: info.endStr })
+          .select()
+          .single();
+        if (!error && data) {
+          calendar.addEvent({ id: data.id, title, start: info.startStr, end: info.endStr });
+        }
+      }
+      calendar.unselect();
+    },
+    eventDrop: async (info) => {
+      if (supabaseCalendarClient) {
+        const { error } = await supabaseCalendarClient
+          .from('eventos')
+          .update({ inicio: info.event.start.toISOString(), fin: info.event.end.toISOString() })
+          .eq('id', info.event.id);
+        if (error) info.revert();
+      }
+    },
+    eventResize: async (info) => {
+      if (supabaseCalendarClient) {
+        const { error } = await supabaseCalendarClient
+          .from('eventos')
+          .update({ inicio: info.event.start.toISOString(), fin: info.event.end.toISOString() })
+          .eq('id', info.event.id);
+        if (error) info.revert();
+      }
+    },
+    eventClick: async (info) => {
+      if (confirm('¿Eliminar evento?') && supabaseCalendarClient) {
+        const { error } = await supabaseCalendarClient
+          .from('eventos')
+          .delete()
+          .eq('id', info.event.id);
+        if (!error) info.event.remove();
+      }
+    }
+  });
+
+  if (supabaseCalendarClient) {
+    const { data: events } = await supabaseCalendarClient
+      .from('eventos')
+      .select('id, titulo, inicio, fin');
+    if (events) {
+      events.forEach(ev => {
+        calendar.addEvent({
+          id: ev.id,
+          title: ev.titulo,
+          start: ev.inicio,
+          end: ev.fin
+        });
+      });
+    }
+  }
+  calendar.render();
+});


### PR DESCRIPTION
## Summary
- create new Material Design calendar page with FullCalendar
- fetch and manage events from Supabase
- link Agenda from index launcher

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6877899d78088329993fa124461cf32d