### PR TITLE
Set turnos view as default after login

### DIFF
--- a/cuidapp.css
+++ b/cuidapp.css
@@ -26,3 +26,5 @@ th{ background:#f6f8f9; }
 tr:nth-child(even) td{ background:#fafafa; }
 button{ background:#1a73e8; color:white; border:none; cursor:pointer; border-radius:4px; }
 button:hover{ background:#1765c1; }
+
+td.libre{ background:rgba(255,0,0,0.3); }

--- a/cuidapp.html
+++ b/cuidapp.html
@@ -43,7 +43,9 @@
         </section>
 
         <section id="view-turnos" class="view">
-            <h2>Grilla de Turnos</h2>
+            <h2 id="turnos-nombre"></h2>
+            <p id="turnos-ubicacion"></p>
+            <h3>Grilla de Turnos</h3>
             <table id="tabla-turnos"></table>
             <button id="btn-volver-dash1">Volver</button>
         </section>

--- a/cuidapp.js
+++ b/cuidapp.js
@@ -143,6 +143,9 @@
     }
 
     function renderTurnos(){
+        document.getElementById('turnos-nombre').textContent=current?current.nombre:'';
+        document.getElementById('turnos-ubicacion').textContent=current&&current.habitacion?`Habitación: ${current.habitacion}`:'';
+
         const table=document.getElementById('tabla-turnos');
         table.innerHTML='';
         const now=new Date();
@@ -159,8 +162,10 @@
             `<td data-slot="t">${turnosCache[key].t}</td>`+
             `<td data-slot="n">${turnosCache[key].n}</td>`;
             row.querySelectorAll('td[data-slot]').forEach(td=>{
+                const slot=td.getAttribute('data-slot');
+                if(!turnosCache[key][slot]) td.classList.add('libre');
+                else td.classList.remove('libre');
                 td.onclick=async()=>{
-                    const slot=td.getAttribute('data-slot');
                     const name=turnosCache[key][slot];
                     const nuevo=prompt('Nombre del cuidador (vacío para liberar)',name);
                     if(nuevo===null)return;
@@ -199,10 +204,10 @@
         if(!pac){alert('Código no encontrado');return;}
         current=pac;
         document.getElementById('dash-nombre').textContent=current.nombre;
-        show('dash');
         await cargarTurnos();
         await cargarBitacora();
         updateInfo();
+        show('turnos');
     };
 
     document.getElementById('btn-logout').onclick=()=>{current=null;show('login');};


### PR DESCRIPTION
## Summary
- show patient info in turnos view and highlight empty slots
- use turnos grid as initial view on login

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778b9109a08329a96c330603400a5a