### PR TITLE
Improve CuidApp header and free slot styling

### DIFF
--- a/cuidapp.css
+++ b/cuidapp.css
@@ -6,10 +6,14 @@ body{
     background:#f1f3f4;
 }
 header{
-    background:#1a73e8;
-    color:white;
+    background:#fff;
+    color:#000;
     padding:12px;
     text-align:center;
+    box-shadow:0 2px 4px rgba(0,0,0,0.1);
+}
+header img{
+    height:40px;
 }
 .view{ display:none; padding:20px; max-width:600px; margin:0 auto; }
 .view.active{ display:block; }
@@ -27,4 +31,15 @@ tr:nth-child(even) td{ background:#fafafa; }
 button{ background:#1a73e8; color:white; border:none; cursor:pointer; border-radius:4px; }
 button:hover{ background:#1765c1; }
 
-td.libre{ background:rgba(255,0,0,0.3); }
+td.libre{
+    background:#fff;
+    color:#e53935;
+    font-weight:bold;
+    text-align:center;
+    position:relative;
+}
+td.libre::before{
+    content:'+';
+    color:#e53935;
+    font-size:1.2em;
+}

--- a/cuidapp.html
+++ b/cuidapp.html
@@ -8,7 +8,7 @@
 </head>
 <body>
     <header>
-        <h1>CuidApp</h1>
+        <img src="header_cuidar.png" alt="CuidApp" id="logo-cuidapp">
     </header>
     <main id="view-container">
         <section id="view-login" class="view active">

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
             <span>LibroVa</span>
         </a>
         <a href="cuidapp.html" class="app-tile">
-            <img src="header.png" alt="CuidApp">
+            <img src="header_cuidar.png" alt="CuidApp">
             <span>CuidApp</span>
         </a>
         <a href="calendar.html" class="app-tile">


### PR DESCRIPTION
## Summary
- update CuidApp header to use `header_cuidar.png`
- adjust CSS for Human Interface Guidelines look
- display red `+` for all free slots in the schedule
- update launcher icon for CuidApp

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877e9a0c5fc8329969a7d45f765a1a1