### PR TITLE
Improve calendar navigation

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -13,6 +13,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     locale: 'es',
     selectable: true,
     editable: true,
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'dayGridMonth,timeGridWeek,timeGridDay'
+    },
+    dayHeaderFormat: { weekday: 'long', day: 'numeric', month: 'numeric' },
     select: async (info) => {
       const title = prompt('Título del evento:');
       if (title && supabaseCalendarClient) {


### PR DESCRIPTION
## Summary
- allow navigating weeks in calendar and show month/day/week view buttons
- display Spanish day names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6877f01a7a2c8329967df5a546ac6c13