### PR TITLE
Limit background video to launcher page

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,7 @@ Los archivos EPUB se muestran directamente en la página gracias a [epub.js](htt
 
 ## Video de fondo
 
-La página principal muestra el video `fondo.mp4` como fondo animado. Puedes
-reemplazar el archivo por otro video o eliminar el elemento
-`<video id="background-video">` en `librova.html` si prefieres solo la imagen de
-fondo estática `fondo.jpg`.
+La página de inicio (`index.html`) utiliza el video `fondo.mp4` como fondo animado. Las demás páginas muestran la imagen estática `fondo.jpg` con el logo centrado en la cabecera.
 
 ## Credenciales de Supabase
 

--- a/cuidapp.html
+++ b/cuidapp.html
@@ -5,23 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CuidApp</title>
     <link rel="stylesheet" href="cuidapp.css">
-    <style>
-        /* Background video style matching LibroVa */
-        #background-video {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            object-fit: cover;
-            z-index: -1;
-        }
-    </style>
 </head>
 <body>
-    <video id="background-video" autoplay muted loop>
-        <source src="fondo.mp4" type="video/mp4">
-    </video>
     <header>
         <img src="header_cuidar.png" alt="CuidApp" id="logo-cuidapp">
     </header>

--- a/librova.html
+++ b/librova.html
@@ -7,9 +7,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <video id="background-video" autoplay muted loop>
-        <source src="fondo.mp4" type="video/mp4">
-    </video>
     <header>
         <div id="logo-container">
             <img src="header.png" alt="LibroVa Logo" id="logo-img">


### PR DESCRIPTION
## Summary
- remove background video from `librova.html` and `cuidapp.html`
- update README to clarify that the animated video is only used on `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877f93af11483299443fe611f049c9a