### PR TITLE
Fix bitacora timezone

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -143,7 +143,7 @@
         bitacoraCache.forEach(b=>{
             const p=document.createElement('p');
             const autor = b.cuidapp_usuarios ? b.cuidapp_usuarios.nombre : '';
-            p.textContent = `[${new Date(b.fecha_hora).toLocaleString()}] ${autor ? autor+': ' : ''}${b.texto}`;
+            p.textContent = `[${new Date(b.fecha_hora).toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires' })}] ${autor ? autor+': ' : ''}${b.texto}`;
             div.appendChild(p);
         });
     }


### PR DESCRIPTION
## Summary
- show bitácora timestamps using the Argentina timezone

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878170fc6d08329b752efc51b821bac