### PR TITLE
Simplify CuidApp dashboard

### DIFF
--- a/cuidapp.html
+++ b/cuidapp.html
@@ -31,11 +31,9 @@
         <section id="view-dashboard" class="view">
             <h2 id="dash-nombre"></h2>
             <div>
-                <button id="goto-turnos">Turnos</button>
-                <button id="goto-info">Información</button>
+                <button id="goto-turnos">📅 Turnos</button>
             </div>
-            <div id="cover-status"></div>
-            <button id="btn-logout">Salir</button>
+            <button id="btn-volver">Volver</button>
         </section>
 
         <section id="view-turnos" class="view">
@@ -51,12 +49,6 @@
             <button id="btn-agregar-bitacora">Agregar</button>
 
             <button id="btn-volver-dash1">Volver</button>
-        </section>
-
-        <section id="view-info" class="view">
-            <h2>Información</h2>
-            <div id="info-detalle"></div>
-            <button id="btn-volver-dash3">Volver</button>
         </section>
     </main>
     <script src="js/supabase.js"></script>

--- a/cuidapp.js
+++ b/cuidapp.js
@@ -3,8 +3,7 @@
         login:document.getElementById('view-login'),
         create:document.getElementById('view-create'),
         dash:document.getElementById('view-dashboard'),
-        turnos:document.getElementById('view-turnos'),
-        info:document.getElementById('view-info')
+        turnos:document.getElementById('view-turnos')
     };
 
     const supabase = window.supabase.createClient(X_SUPABASE_URL, X_SUPABASE_ANON_KEY);
@@ -205,24 +204,6 @@
             });
             table.appendChild(row);
         }
-        updateCoverStatus();
-    }
-
-    function updateInfo(){
-        const info=document.getElementById('info-detalle');
-        const hosp = current && current.hospital_id ? `🏥 ${current.hospital_id}` : '';
-        const ubic = current ? `🏢 ${current.piso||current.habitacion||''} (${current.horario_visita||''})` : '';
-        info.innerHTML=`<p>${hosp}</p><p>${ubic}</p>`;
-        updateCoverStatus();
-    }
-
-    function updateCoverStatus(){
-        let total=0,ocupados=0;
-        for(const d of Object.values(turnosCache)){
-            ['m','t','n'].forEach(s=>{total++;if(d[s])ocupados++;});
-        }
-        const perc=total?Math.round(ocupados*100/total):0;
-        document.getElementById('cover-status').textContent=`Cobertura: ${perc}%`;
     }
 
     const selLogin=document.getElementById('login-select');
@@ -237,7 +218,6 @@
         document.getElementById('dash-nombre').textContent=current.nombre;
         await cargarTurnos();
         await cargarBitacora();
-        updateInfo();
         show('turnos');
     }
 
@@ -246,10 +226,9 @@
         if(code) await loginPorCodigo(code);
     };
 
-    document.getElementById('btn-logout').onclick=()=>{current=null;show('login');};
+    document.getElementById('btn-volver').onclick=()=>{current=null;show('login');};
     document.getElementById('goto-turnos').onclick=()=>{renderTurnos();renderBitacora();show('turnos');};
-    document.getElementById('goto-info').onclick=()=>{updateInfo();show('info');};
-    document.getElementById('btn-volver-dash1').onclick=document.getElementById('btn-volver-dash3').onclick=()=>show('dash');
+    document.getElementById('btn-volver-dash1').onclick=()=>show('dash');
 
     document.getElementById('btn-agregar-bitacora').onclick=async()=>{
         const txt=document.getElementById('bitacora-text').value.trim();


### PR DESCRIPTION
## Summary
- remove unused info screen and coverage indicator
- rename exit button to `Volver`
- only show a single "📅 Turnos" button on the patient dashboard

## Testing
- `node --check cuidapp.js`

------
https://chatgpt.com/codex/tasks/task_e_6878202aac588329881d9eff00c2a98a