### PR TITLE
Fix bitacora timezone display

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -151,7 +151,7 @@
         bitacoraCache.forEach(b=>{
             const p=document.createElement('p');
             const autor = b.cuidapp_usuarios ? b.cuidapp_usuarios.nombre : '';
-            p.textContent = `[${new Date(b.fecha_hora).toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires' })}] ${autor ? autor+': ' : ''}${b.texto}`;
+            p.textContent = `[${new Date(b.fecha_hora).toLocaleString()}] ${autor ? autor + ': ' : ''}${b.texto}`;
             div.appendChild(p);
         });
     }


### PR DESCRIPTION
## Summary
- revert explicit timezone in `renderBitacora` so the browser's local time is used

## Testing
- `node -e "console.log(new Date('2025-07-17T11:38:57Z').toLocaleString())"`

------
https://chatgpt.com/codex/tasks/task_e_6878e12bf0b883298eda87b4016f4edc