### PR TITLE
Add logout icon in CuidApp header

### DIFF
--- a/cuidapp.css
+++ b/cuidapp.css
@@ -29,6 +29,16 @@ header{
     margin-left:auto;
     font-weight:bold;
 }
+#btn-cerrar-sesion {
+    margin-left:10px;
+    background:none;
+    border:none;
+    cursor:pointer;
+    font-size:1.2em;
+}
+#btn-cerrar-sesion:hover {
+    transform:scale(1.1);
+}
 header img{
     height:80px;
 

--- a/cuidapp.html
+++ b/cuidapp.html
@@ -10,6 +10,7 @@
     <header>
         <img src="header_cuidar.png" alt="CuidApp" id="logo-cuidapp">
         <span id="cuidador-display"></span>
+        <button id="btn-cerrar-sesion" title="Cerrar sesi&#243;n">🚪</button>
     </header>
     <main id="view-container">
         <section id="view-login" class="view active">

--- a/cuidapp.js
+++ b/cuidapp.js
@@ -12,6 +12,7 @@
     let bitacoraCache=[];
 
     const spanNombre = document.getElementById('cuidador-display');
+    const btnCerrarSesion = document.getElementById('btn-cerrar-sesion');
 
     function obtenerNombreCuidador(){
         let nc = localStorage.getItem('cuidadorNombre') || '';
@@ -25,6 +26,14 @@
 
     let nombreCuidador = obtenerNombreCuidador();
     if(spanNombre) spanNombre.textContent = nombreCuidador ? `Bienvenido ${nombreCuidador}` : '';
+
+    function cerrarSesion(){
+        localStorage.removeItem('cuidadorNombre');
+        if(spanNombre) spanNombre.textContent='';
+        location.reload();
+    }
+
+    if(btnCerrarSesion) btnCerrarSesion.addEventListener('click', cerrarSesion);
 
     async function cargarListaPacientes(){
         const sel=document.getElementById('login-select');


### PR DESCRIPTION
## Summary
- add a logout button in CuidApp header
- style the new logout icon
- implement logout logic to clear stored name and reload

## Testing
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6878e2066df08329b19db0454c0f3eb3