### PR TITLE
Fix bitacora timezone display

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -151,7 +151,9 @@
         bitacoraCache.forEach(b=>{
             const p=document.createElement('p');
             const autor = b.cuidapp_usuarios ? b.cuidapp_usuarios.nombre : '';
-            p.textContent = `[${new Date(b.fecha_hora).toLocaleString('es-AR', { timeZone: 'America/Argentina/Buenos_Aires' })}] ${autor ? autor+': ' : ''}${b.texto}`;
+            const fecha = new Date(b.fecha_hora);
+            fecha.setHours(fecha.getHours() - 3);
+            p.textContent = `[${fecha.toLocaleString()}] ${autor ? autor + ': ' : ''}${b.texto}`;
             div.appendChild(p);
         });
     }


### PR DESCRIPTION
## Summary
- show bitacora entries 3 hours earlier to correct server offset

## Testing
- `node -e "const d=new Date('2025-07-17T11:38:57'); d.setHours(d.getHours()-3); console.log(d.toLocaleString())"`

------
https://chatgpt.com/codex/tasks/task_e_6878e12bf0b883298eda87b4016f4edc