### PR TITLE
Add logout icon in CuidApp header

### DIFF
--- a/cuidapp.css
+++ b/cuidapp.css
@@ -25,9 +25,23 @@ header{
     display:flex;
     align-items:center;
 }
-#cuidador-display {
+#user-info {
     margin-left:auto;
+    display:flex;
+    align-items:center;
     font-weight:bold;
+}
+#cuidador-display {
+    margin-right:4px;
+}
+#btn-cerrar-sesion {
+    background:none;
+    border:none;
+    cursor:pointer;
+    font-size:1.2em;
+}
+#btn-cerrar-sesion:hover {
+    transform:scale(1.1);
 }
 header img{
     height:80px;

--- a/cuidapp.html
+++ b/cuidapp.html
@@ -9,7 +9,10 @@
 <body>
     <header>
         <img src="header_cuidar.png" alt="CuidApp" id="logo-cuidapp">
-        <span id="cuidador-display"></span>
+        <div id="user-info">
+            <span id="cuidador-display"></span>
+            <button id="btn-cerrar-sesion" title="Cerrar sesi&#243;n">🚪</button>
+        </div>
     </header>
     <main id="view-container">
         <section id="view-login" class="view active">

--- a/cuidapp.js
+++ b/cuidapp.js
@@ -12,6 +12,7 @@
     let bitacoraCache=[];
 
     const spanNombre = document.getElementById('cuidador-display');
+    const btnCerrarSesion = document.getElementById('btn-cerrar-sesion');
 
     function obtenerNombreCuidador(){
         let nc = localStorage.getItem('cuidadorNombre') || '';
@@ -25,6 +26,14 @@
 
     let nombreCuidador = obtenerNombreCuidador();
     if(spanNombre) spanNombre.textContent = nombreCuidador ? `Bienvenido ${nombreCuidador}` : '';
+
+    function cerrarSesion(){
+        localStorage.removeItem('cuidadorNombre');
+        if(spanNombre) spanNombre.textContent='';
+        location.reload();
+    }
+
+    if(btnCerrarSesion) btnCerrarSesion.addEventListener('click', cerrarSesion);
 
     async function cargarListaPacientes(){
         const sel=document.getElementById('login-select');


### PR DESCRIPTION
## Summary
- add a logout button in CuidApp header
- style the new logout icon
- implement logout logic to clear stored name and reload
- adjust layout so the welcome text and icon sit together

## Testing
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6878e2066df08329b19db0454c0f3eb3