### PR TITLE
Add root admin role for CuidApp

### DIFF
--- a/cuidapp.html
+++ b/cuidapp.html
@@ -23,6 +23,12 @@
             <button id="btn-show-create">Agregar paciente</button>
         </section>
 
+        <section id="view-admin" class="view">
+            <h2>Administraci&#243;n de Pacientes</h2>
+            <div id="admin-pacientes"></div>
+            <button id="btn-admin-volver">Volver</button>
+        </section>
+
         <section id="view-create" class="view">
             <h2>Registrar Paciente</h2>
             <input type="text" id="pac-nombre" placeholder="Nombre completo">


### PR DESCRIPTION
## Summary
- add admin login and panel to CuidApp
- support editing and deleting patients along with their schedules and notes
- remove separate admin login view and button; entering user name 'root' now loads admin panel automatically

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -c cuidapp.js`


------
https://chatgpt.com/codex/tasks/task_e_6878f506b444832987bad1a1a59514f3