### PR TITLE
Corrige duplicación de hospital en pantalla de usuario

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -243,7 +243,6 @@
             document.getElementById('turnos-nombre').textContent = `🤒 ${current.nombre}`;
             const hosp = current.hospital_id ? `🏥 ${current.hospital_id}` : '';
             const partes = [];
-            if(current.hospital_id) partes.push(current.hospital_id);
             if(current.piso || current.habitacion) partes.push(current.piso || current.habitacion);
             if(current.horario_visita) partes.push(`Visita de ${current.horario_visita}`);
             const info = partes.length ? `🏢 ${partes.join(' - ')}` : '';


### PR DESCRIPTION
## Summary
- evita repetir el nombre del hospital en la vista de turnos para pacientes

## Testing
- `npm test` *(falla: no se encontró `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68791099d9008329a6ac7c12f3c4b9b2