### PR TITLE
Fix patient list rendering for older browsers

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -64,8 +64,10 @@
         if(error) return;
         (data||[]).forEach(p=>{
             const opt=document.createElement('option');
-            opt.value=p.codigo_acceso;
-            opt.textContent=p.cuidapp_pacientes?.nombre||p.codigo_acceso;
+            opt.value = p.codigo_acceso;
+            opt.textContent = (p.cuidapp_pacientes && p.cuidapp_pacientes.nombre)
+                ? p.cuidapp_pacientes.nombre
+                : p.codigo_acceso;
             sel.appendChild(opt);
         });
     }


### PR DESCRIPTION
## Summary
- avoid optional chaining in patient list rendering for broader browser support

## Testing
- `node test_app_test.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6879338bb64c832990ba98ddfa867466