### PR TITLE
Allow root to edit schedule slots

### DIFF
--- a/cuidapp.js
+++ b/cuidapp.js
@@ -306,6 +306,13 @@
                 else td.classList.remove('libre');
                 td.onclick = async () => {
                     const name = turnosCache[key][slot];
+                    const isRoot = nombreCuidador && nombreCuidador.toLowerCase() === 'root';
+                    if (isRoot) {
+                        const nuevo = prompt('Nombre del cuidador (vacío para liberar)', name || '');
+                        if (nuevo === null) return;
+                        await actualizarTurno(key, slot, (nuevo || '').trim());
+                        return;
+                    }
                     if (!name && nombreCuidador) {
                         await actualizarTurno(key, slot, nombreCuidador);
                     } else if (name === nombreCuidador) {


### PR DESCRIPTION
## Summary
- make root user always prompt for a caregiver name when clicking a slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68793d86353c8329a5a0466ec6ba14b2