### PR TITLE
Improve calendar header

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -24,13 +24,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     },
 
     dayHeaderContent: (arg) => {
-      const formatted = new Intl.DateTimeFormat('es', {
-        weekday: 'long',
-        day: 'numeric',
-        month: 'numeric'
-      }).format(arg.date);
-      const clean = formatted.replace(',', '');
-      return { html: clean.charAt(0).toUpperCase() + clean.slice(1) };
+      let dayShort = new Intl.DateTimeFormat('es', { weekday: 'short' }).format(arg.date);
+      dayShort = dayShort.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+      dayShort = dayShort.charAt(0).toUpperCase() + dayShort.slice(1);
+      const dayNum = new Intl.DateTimeFormat('es', { day: 'numeric', month: 'numeric' }).format(arg.date);
+      return { html: `${dayShort} ${dayNum}` };
     },
 
     select: async (info) => {


### PR DESCRIPTION
## Summary
- shorten calendar day headers to three letters

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68797fa9016083298a77fb4dddc00f64