### PR TITLE
Improve calendar header

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -24,13 +24,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     },
 
     dayHeaderContent: (arg) => {
-      const formatted = new Intl.DateTimeFormat('es', {
-        weekday: 'long',
+      const names = ['Dom', 'Lun', 'Mar', 'Mie', 'Jue', 'Vie', 'Sab'];
+      const dayName = names[arg.date.getDay()];
+      const dayNum = new Intl.DateTimeFormat('es', {
         day: 'numeric',
         month: 'numeric'
       }).format(arg.date);
-      const clean = formatted.replace(',', '');
-      return { html: clean.charAt(0).toUpperCase() + clean.slice(1) };
+      return { html: `${dayName} ${dayNum}` };
     },
 
     select: async (info) => {


### PR DESCRIPTION
## Summary
- shorten calendar day headers to three letters

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68797fa9016083298a77fb4dddc00f64